### PR TITLE
Release/1.6.0 beta

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Easily launch and manage multilingual Craft websites without having to copy/paste content or manually track updates.",
-    "pluginVersion": "1.5.1",
+    "pluginVersion": "1.6.0",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.0 - 2020-04-13
+
+### Added
+- Support links to About page
+- Setting to disable duplicate message warning
+- In Review status to API orders
+- User-friendly exported ZIP filenames
+- Support for Thai th-TH ISO code
+
+### Updated
+- Filenames for API orders to ensure they are unique
+- Logic for adding & removing entries from new order screen
+
+### Fixed
+- Namespacing issue with static translations
+- Craft 3.4+ incompatability with Globals translation drafts
+- Resolved issue with pre-selected target sites on previously saved orders
+- Redirect for failed orders due to unsupported ISO codes
+
 ## 1.5.1 - 2020-03-10
 
 ### Added

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -342,7 +342,7 @@ class Translations extends Plugin
                     'translations/settings/settings-check' => 'translations/settings/settings-check',
                     'translations/settings/send-logs' => 'translations/settings/send-logs',
                     'translations/orders/get-file-diff/<fileId:\d+>' => 'translations/base/get-file-diff',
-                    'translations/settings/setting' => 'translations/settings/settings',
+                    'translations/settings/configuration-options' => 'translations/settings/configuration-options',
                 ]);
             }
         );

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -184,6 +184,11 @@ class Translations extends Plugin
             ),
             __METHOD__
         );
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        if ($projectConfig->get('chkDuplicateEntries') === NULL){
+            $projectConfig->set('chkDuplicateEntries', 1, 'Update system settings.');
+        }
     }
 
     /**

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -337,6 +337,7 @@ class Translations extends Plugin
                     'translations/settings/settings-check' => 'translations/settings/settings-check',
                     'translations/settings/send-logs' => 'translations/settings/send-logs',
                     'translations/orders/get-file-diff/<fileId:\d+>' => 'translations/base/get-file-diff',
+                    'translations/settings/setting' => 'translations/settings/settings',
                 ]);
             }
         );

--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -617,3 +617,11 @@
     display: inline-block;
     padding: 0 10px ;
 }
+
+.translations-about .link {
+    padding-bottom: 15px;
+}
+
+.translations-about .link a {
+    padding-right: 15px;
+}

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -167,6 +167,9 @@ Craft.Translations.OrderDetail = {
                 param = 'admin/translations/orders/new'+param;
 
                 window.history.pushState("object or string", "Translations", "/"+param);
+                var currentElementIds = $('#currentElementIds').val();
+                currentElementIds = currentElementIds.replace($button.attr('data-element'), '').replace(',,', ',');
+                $('#currentElementIds').val(currentElementIds);
             }
         });
 

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -328,7 +328,19 @@ Craft.Translations.OrderDetail = {
             $(window).off('beforeunload.windowReload');
             var site = $("#sourceSiteSelect").val();
             var url = document.URL;
-            url = url.replace(/(sourceSite=).*?(&)/,'$1' + site + '$2');
+            url = url.split('?');
+            url = url[0];
+
+            var currentElementIds = [];
+            if (typeof $('#currentElementIds').val() !== 'undefined') {
+                currentElementIds = $('#currentElementIds').val().split(',');
+            }
+            url += '?sourceSite='+site;
+            if (currentElementIds) {
+                currentElementIds.forEach(function (element) {
+                    url += '&elements[]='+element;
+                })
+            }
             if(url.indexOf('#step2') == -1) {
                 url += '#step2';
             }
@@ -348,6 +360,7 @@ Craft.Translations.OrderDetail = {
             elementIds = currentElementIds = [];
 
             var sourceSites = [];
+            var site = $("#sourceSiteSelect").val();
             $("input:hidden.sourceSites").each(function() {
                 sourceSites.push($(this).val());
             });
@@ -384,7 +397,7 @@ Craft.Translations.OrderDetail = {
                             }
                         }
                         if ($('#addNewEntries').val() == 1) {
-                            window.location.href=Craft.getUrl('translations/orders/new')+'?sourceSite='+elementUrl;
+                            window.location.href=Craft.getUrl('translations/orders/new')+'?sourceSite='+site+elementUrl;
                         } else {
                             addEntries();
 

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -161,6 +161,12 @@ Craft.Translations.OrderDetail = {
                 $('[data-order-attribute=entriesCount]').text(entriesCount);
 
                 $('[data-order-attribute=wordCount]').text(wordCount);
+
+                var param = window.location.search;
+                param = param.replace("&elements[]="+$button.attr('data-element'), "");
+                param = 'admin/translations/orders/new'+param;
+
+                window.history.pushState("object or string", "Translations", "/"+param);
             }
         });
 

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -365,12 +365,18 @@ Craft.Translations.OrderDetail = {
                 sourceSites.push($(this).val());
             });
 
+            var currentElementIds = [];
+            if (typeof $('#currentElementIds').val() !== 'undefined') {
+                currentElementIds = $('#currentElementIds').val().split(',');
+            }
+
             this.assetSelectionModal = Craft.createElementSelectorModal('craft\\elements\\Entry', {
                 storageKey: null,
                 sources: null,
                 elementIndex: null,
                 criteria: {siteId: this.elementSiteId},
                 multiSelect: 1,
+                disabledElementIds: currentElementIds,
                 onSelect: $.proxy(function(elements) {
 
                     $('#content').addClass('elements busy');

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -989,8 +989,7 @@ class BaseController extends Controller
                                     Craft::error('Couldn’t save the order', __METHOD__);
                                 }
                                 Craft::$app->getSession()->setError(Translations::$plugin->translator->translate('app', 'The following language pair(s) are not supported: '.implode(', ', array_column($unsupportedLangs, 'language')).' Contact Acclaro for assistance.'));
-                                // return; // @todo This might be a better idea than failing the order
-                                return $this->redirect('translations/orders', 302, true);
+                                return $this->redirect('translations/orders/detail/'. $order->id);
                             }
 
                         } else {

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -480,6 +480,9 @@ class BaseController extends Controller
 
         $variables['duplicateEntries'] = $this->checkOrderDuplicates($variables['elements']);
 
+        $projectConfig = Craft::$app->getProjectConfig();
+        $variables['chkDuplicateEntries'] = $projectConfig->get('chkDuplicateEntries');
+
         $variables['orderEntriesCount'] = count($variables['elements']);
 
         $variables['orderWordCount'] = 0;

--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -71,10 +71,10 @@ class FilesController extends Controller
         $orderAttributes = $order->getAttributes();
 
         //Filename Zip Folder
-        $zipName = $orderAttributes['id'].'_'.$orderAttributes['sourceSite'];
+        $zipName = $this->getZipName($orderAttributes);
         
         // Set destination zip
-        $zipDest = Craft::$app->path->getTempPath().'/'.$zipName.'_'.time().'.zip';
+        $zipDest = Craft::$app->path->getTempPath().'/'.$zipName.'.zip';
         
         // Create zip
         $zip = new ZipArchive();
@@ -414,6 +414,21 @@ class FilesController extends Controller
     	}
 
     	return $msg;
+    }
+
+    /**
+     * @param $order
+     * @return string
+     */
+    public function getZipName($order) {
+
+        $title = str_replace(' ', '_', $order['title']);
+        $title = preg_replace('/[^A-Za-z0-9\-_]/', '', $title);
+        $len = 50;
+        $title = (strlen($title) > $len) ? substr($title,0,$len) : $title;
+        $zip_name =  $title.'_'.$order['id'];
+
+        return $zip_name;
     }
 
 }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -223,7 +223,7 @@ class SettingsController extends Controller
         return FileHelper::unlink($zipDest);
     }
 
-    public function actionSettings()
+    public function actionConfigurationOptions()
     {
         $this->requireLogin();
         if (!Translations::$plugin->userRepository->userHasAccess('translations:settings:clear-orders')) {
@@ -233,10 +233,10 @@ class SettingsController extends Controller
         $projectConfig = Craft::$app->getProjectConfig();
         $variables['chkDuplicateEntries'] = $projectConfig->get('chkDuplicateEntries');
 
-        $this->renderTemplate('translations/settings/setting', $variables);
+        $this->renderTemplate('translations/settings/configuration-options', $variables);
     }
 
-    public function actionSetSettings()
+    public function actionSaveConfigurationOptions()
     {
         $this->requireLogin();
         if (!Translations::$plugin->userRepository->userHasAccess('translations:settings:clear-orders')) {

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -222,4 +222,37 @@ class SettingsController extends Controller
 
         return FileHelper::unlink($zipDest);
     }
+
+    public function actionSettings()
+    {
+        $this->requireLogin();
+        if (!Translations::$plugin->userRepository->userHasAccess('translations:settings:clear-orders')) {
+            return;
+        }
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $variables['chkDuplicateEntries'] = $projectConfig->get('chkDuplicateEntries');
+
+        $this->renderTemplate('translations/settings/setting', $variables);
+    }
+
+    public function actionSetSettings()
+    {
+        $this->requireLogin();
+        if (!Translations::$plugin->userRepository->userHasAccess('translations:settings:clear-orders')) {
+            return;
+        }
+
+        $request = Craft::$app->getRequest();
+        $duplicateEntries = $request->getParam('chkDuplicateEntries');
+
+        try {
+            $projectConfig = Craft::$app->getProjectConfig();
+            $projectConfig->set('chkDuplicateEntries', $duplicateEntries, 'Update system settings.');
+
+            Craft::$app->getSession()->setNotice(Translations::$plugin->translator->translate('app', 'Setting saved.'));
+        } catch (\Throwable $th) {
+            Craft::$app->getSession()->setError(Translations::$plugin->translator->translate('app', 'Unable to save setting.'));
+        }
+    }
 }

--- a/src/models/GlobalSetDraftModel.php
+++ b/src/models/GlobalSetDraftModel.php
@@ -18,6 +18,8 @@ use craft\validators\DateTimeValidator;
 use acclaro\translations\services\App;
 use acclaro\translations\Translations;
 use acclaro\translations\records\GlobalSetDraftRecord;
+use craft\behaviors\FieldLayoutBehavior;
+use craft\behaviors\DraftBehavior;
 
 use Craft;
 use craft\base\Model;
@@ -143,5 +145,26 @@ class GlobalSetDraftModel extends GlobalSet
         $path = 'translations/globals/'.$globalSet->handle.'/drafts/'.$this->draftId;
         
         return Translations::$plugin->urlHelper->cpUrl($path);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['fieldLayout'] = [
+            'class' => FieldLayoutBehavior::class,
+            'elementType' => GlobalSet::class,
+        ];
+        $behaviors['draft'] = [
+            'class' => DraftBehavior::class,
+            'sourceId' => $this->id,
+            'creatorId' => 1,
+            'draftName' => 'Global Draft',
+            'draftNotes' => '',
+            'trackChanges' => true,
+        ];
+        return $behaviors;
     }
 }

--- a/src/services/fieldtranslator/SuperTableFieldTranslator.php
+++ b/src/services/fieldtranslator/SuperTableFieldTranslator.php
@@ -116,6 +116,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
                       'type' => $blockType->id,
                       'fields' => $elementTranslator->toPostArrayFromTranslationTarget($elem, $sourceLanguage, $targetLanguage, $blockData, true),
                     );
+                    $n++;
                   }
               } else {
                 $blockData = isset($fieldData[$new]) ? $fieldData[$new] : array();

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -291,9 +291,9 @@ class OrderRepository
             $targetSite = Translations::$plugin->siteRepository->normalizeLanguage(Craft::$app->getSites()->getSiteById($file->targetSite)->language);
 
             if ($element instanceof GlobalSetModel) {
-                $filename = ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                $filename = $file->elemendId. '-'.ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
             } else {
-                $filename = $element->slug.'-'.$targetSite.'.xml';
+                $filename = $file->elemendId. '-'.$element->slug.'-'.$targetSite.'.xml';
             }
 
             $path = $tempPath.'/'.$filename;

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -291,12 +291,12 @@ class OrderRepository
             $targetSite = Translations::$plugin->siteRepository->normalizeLanguage(Craft::$app->getSites()->getSiteById($file->targetSite)->language);
 
             if ($element instanceof GlobalSetModel) {
-                $filename = $file->elemendId. '-'.ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                $filename = ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
             } else {
-                $filename = $file->elemendId. '-'.$element->slug.'-'.$targetSite.'.xml';
+                $filename = $element->slug.'-'.$targetSite.'.xml';
             }
 
-            $path = $tempPath.'/'.$filename;
+            $path = $tempPath .'/'. $file->elementId .'-'. $filename;
 
             $stream = fopen($path, 'w+');
 

--- a/src/services/repository/SiteRepository.php
+++ b/src/services/repository/SiteRepository.php
@@ -112,6 +112,7 @@ class SiteRepository
         'tam' => 'ta',               //Tamil
         'tel' => 'te',               //Telugu
         'tha' => 'th',               //Thai
+        'th-TH' => 'th',             //Thai
         'tur' => 'tr',               //Turkish
         'ukr' => 'uk',               //Ukrainian
         'urd' => 'ur',               //Urdu

--- a/src/services/repository/TranslationRepository.php
+++ b/src/services/repository/TranslationRepository.php
@@ -145,22 +145,22 @@ class TranslationRepository
         $reflectionProperty->setAccessible(true);
         
         // Get i18n messages
-        $messages = $reflectionProperty->getValue(Craft::$app->getI18n()->getMessageSource('site'));
+        $messages = $reflectionProperty->getValue(Craft::$app->getI18n()->getMessageSource('translations'));
         
         // Set site i18n messages from stored translations
         foreach ($translations as $translation) {
             $sourceLanguage = Craft::$app->sites->getSiteById($translation->sourceSite)->language;
             $targetLanguage = Craft::$app->sites->getSiteById($translation->targetSite)->language;
-            $key = sprintf('%s/%s', $targetLanguage, 'site');
+            $key = sprintf('%s/%s', $targetLanguage, 'translations');
             $messages[$key][$translation->source] = $translation->target;
             
             if ($sourceLanguage !== $targetLanguage) {
-                Craft::$app->getI18n()->translate('site', $translation->source, [], $targetLanguage);
+                Craft::$app->getI18n()->translate('translations', $translation->source, [], $targetLanguage);
             }
 
         }
         
-        $reflectionProperty->setValue(Craft::$app->getI18n()->getMessageSource('site'), $messages);
+        $reflectionProperty->setValue(Craft::$app->getI18n()->getMessageSource('translations'), $messages);
         
         $reflectionProperty->setAccessible(false);
     }

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -237,9 +237,9 @@ class AcclaroTranslationService implements TranslationServiceInterface
             $targetSite = Translations::$plugin->siteRepository->normalizeLanguage(Craft::$app->getSites()->getSiteById($file->targetSite)->language);
 
             if ($element instanceof GlobalSetModel) {
-                $filename = ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                $filename = $file->elementId. '-' .ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
             } else {
-                $filename = $element->slug.'-'.$targetSite.'.xml';
+                $filename = $file->elemendId. '-'.$element->slug.'-'.$targetSite.'.xml';
             }
 
             $path = $tempPath.'/'.$filename;

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -237,12 +237,12 @@ class AcclaroTranslationService implements TranslationServiceInterface
             $targetSite = Translations::$plugin->siteRepository->normalizeLanguage(Craft::$app->getSites()->getSiteById($file->targetSite)->language);
 
             if ($element instanceof GlobalSetModel) {
-                $filename = $file->elementId. '-' .ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                $filename = ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
             } else {
-                $filename = $file->elemendId. '-'.$element->slug.'-'.$targetSite.'.xml';
+                $filename = $element->slug.'-'.$targetSite.'.xml';
             }
 
-            $path = $tempPath.'/'.$filename;
+            $path = $tempPath .'/'. $file->elementId .'-'. $filename;
 
             $stream = fopen($path, 'w+');
 

--- a/src/templates/_components/widgets/RecentOrders/body.twig
+++ b/src/templates/_components/widgets/RecentOrders/body.twig
@@ -23,6 +23,8 @@
                             <span class="status"></span>{{order.statusLabel}}
                         {% case "In progress" %}
                             <span class="status orange"></span>{{order.statusLabel}}
+                        {% case "In review" %}
+                            <span class="status yellow"></span>{{order.statusLabel}}
                         {% case "Ready to apply" %}
                             <span class="status blue"></span>{{order.statusLabel}}
                         {% case "Cancelled" %}

--- a/src/templates/_layouts/settings.twig
+++ b/src/templates/_layouts/settings.twig
@@ -25,7 +25,7 @@
                 <a  href="{{ cpUrl('translations/settings/clear-orders') }}" {% if selectedSidebarItem == 'clear-orders' %}class="settings-sel"{% endif %}><div class="translations-icon">{{ svg('@app/icons/trash.svg') }}</div>{{"Clear Orders"|t('app')}}</a>
             </li>
             <li>
-                <a  href="{{ cpUrl('translations/settings/setting') }}" {% if selectedSidebarItem == 'setting' %}class="settings-sel"{% endif %}><div class="translations-icon" style="width: 18px; height: 17px; padding-right: 11px;"> <span class="icon icon-mask"> <span data-icon="settings"></span> </span> {#{{ svg('@app/icons/icon-mask.svg') }} #} </div> {{"Settings"|t('app')}} </a>
+                <a  href="{{ cpUrl('translations/settings/setting') }}" {% if selectedSidebarItem == 'setting' %}class="settings-sel"{% endif %}><div class="translations-icon" style="width: 18px; height: 17px; padding-right: 11px;"> <span class="icon icon-mask"> <span data-icon="settings"></span> </span> {#{{ svg('@app/icons/icon-mask.svg') }} #} </div> {{"Configuration Options"|t('app')}} </a>
             </li>
         </ul>
     </nav>

--- a/src/templates/_layouts/settings.twig
+++ b/src/templates/_layouts/settings.twig
@@ -24,6 +24,9 @@
             <li>
                 <a  href="{{ cpUrl('translations/settings/clear-orders') }}" {% if selectedSidebarItem == 'clear-orders' %}class="settings-sel"{% endif %}><div class="translations-icon">{{ svg('@app/icons/trash.svg') }}</div>{{"Clear Orders"|t('app')}}</a>
             </li>
+            <li>
+                <a  href="{{ cpUrl('translations/settings/setting') }}" {% if selectedSidebarItem == 'setting' %}class="settings-sel"{% endif %}><div class="translations-icon" style="width: 18px; height: 17px; padding-right: 11px;"> <span class="icon icon-mask"> <span data-icon="settings"></span> </span> {#{{ svg('@app/icons/icon-mask.svg') }} #} </div> {{"Settings"|t('app')}} </a>
+            </li>
         </ul>
     </nav>
 

--- a/src/templates/_layouts/settings.twig
+++ b/src/templates/_layouts/settings.twig
@@ -25,7 +25,7 @@
                 <a  href="{{ cpUrl('translations/settings/clear-orders') }}" {% if selectedSidebarItem == 'clear-orders' %}class="settings-sel"{% endif %}><div class="translations-icon">{{ svg('@app/icons/trash.svg') }}</div>{{"Clear Orders"|t('app')}}</a>
             </li>
             <li>
-                <a  href="{{ cpUrl('translations/settings/setting') }}" {% if selectedSidebarItem == 'setting' %}class="settings-sel"{% endif %}><div class="translations-icon" style="width: 18px; height: 17px; padding-right: 11px;"> <span class="icon icon-mask"> <span data-icon="settings"></span> </span> {#{{ svg('@app/icons/icon-mask.svg') }} #} </div> {{"Configuration Options"|t('app')}} </a>
+                <a  href="{{ cpUrl('translations/settings/configuration-options') }}" {% if selectedSidebarItem == 'setting' %}class="settings-sel"{% endif %}><div class="translations-icon" style="width: 18px; height: 17px; padding-right: 11px;"> <span class="icon icon-mask"> <span data-icon="settings"></span> </span> {#{{ svg('@app/icons/icon-mask.svg') }} #} </div> {{"Configuration Options"|t('app')}} </a>
             </li>
         </ul>
     </nav>

--- a/src/templates/globals/_editDraft.html
+++ b/src/templates/globals/_editDraft.html
@@ -59,6 +59,19 @@
         {{ csrfInput() }}
 
         {% if draft.getFieldLayout().getFields() | length %}
+        <div>
+            {% for tab in draft.getFieldLayout().getTabs() %}
+                <div id="{{ tab.getHtmlId() }}"{% if not loop.first %} class="hidden"{% endif %}>
+                    {% include "_includes/fields" with {
+                        fields:  tab.getFields(),
+                        element: draft
+                    } only %}
+                </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {#{% if draft.getFieldLayout().getFields() | length %}
             <div>
                 {% include "_includes/fields" with {
                     fields:  draft.getFieldLayout().getFields(),
@@ -67,6 +80,6 @@
             </div>
         {% else %}
             {{ "This global set doesn’t have any fields assigned to it in its field layout."|t }}
-        {% endif %}
+            {% endif %}#}
     </form>
 {% endblock %}

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -518,6 +518,7 @@
                             <div class="warning-box">
                                 <span class="warning" data-icon="alert"></span> &nbsp;
                                 {{ 'This order contains entries that exist in one or more open orders, select the warning icon beside the Entry for additional details. Remove duplicate entries below or click "Next" to continue.'|t }}
+                                <a href="{{ url('translations/settings/setting') }}"> {{ 'Disable these warnings'|t }} </a>
                             </div>
                         {% endif %}
 

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -565,7 +565,7 @@
                                 <td>{{ element.className == 'craft\\elements\\GlobalSet' ? 'Globals'|t : element.section.name }}</td>
                                 <td>{{ element.dateUpdated ? element.dateUpdated|date('n/j/y') : '' }}</td>
                                 {#<td>{{sourceSite.name}} <span class="light">({{ sourceSite.language }})</span></td>#}
-                                <td><a class="icon delete translations-order-delete-entry" title="{{ 'Delete entry'|t }}"><input type="hidden" name="elements[]" value="{{ element.id }}"></a></td>
+                                <td><a class="icon delete translations-order-delete-entry" data-element="{{ element.id }}" title="{{ 'Delete entry'|t }}"><input type="hidden" name="elements[]" value="{{ element.id }}"></a></td>
                             </tr>
                             {% set elementIds = elementIds|merge({(loop.index0):element.id}) %}
                         {% endfor %}

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -514,7 +514,7 @@
             <div class="translations-order-steps">
                 <div class="translations-order-step{% if orderId is empty %} active{% endif %}" id="step1">
                     <div class="translations-order-step-intro">
-                        {% if duplicateEntries %}
+                        {% if duplicateEntries and chkDuplicateEntries  %}
                             <div class="warning-box">
                                 <span class="warning" data-icon="alert"></span> &nbsp;
                                 {{ 'This order contains entries that exist in one or more open orders, select the warning icon beside the Entry for additional details. Remove duplicate entries below or click "Next" to continue.'|t }}
@@ -553,7 +553,7 @@
                         {% for element in elements %}
                             <tr data-word-count="{{ elementWordCounts[element.id] }}">
                                 <td>{% include "_elements/element" with {'element': element} only %}
-                                    {% if duplicateEntries[element.id] is defined %}
+                                    {% if duplicateEntries[element.id] is defined and chkDuplicateEntries %}
                                         <span class="warning duplicate-warning">
                                             {{ 'This entry exists in ' }}
                                             {% for orderId in duplicateEntries[element.id] %}

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -566,7 +566,7 @@
                                 <td>{{ element.className == 'craft\\elements\\GlobalSet' ? 'Globals'|t : element.section.name }}</td>
                                 <td>{{ element.dateUpdated ? element.dateUpdated|date('n/j/y') : '' }}</td>
                                 {#<td>{{sourceSite.name}} <span class="light">({{ sourceSite.language }})</span></td>#}
-                                <td><a class="icon delete translations-order-delete-entry" data-element="{{ element.id }}" title="{{ 'Delete entry'|t }}"><input type="hidden" name="elements[]" value="{{ element.id }}"></a></td>
+                                <td><a class="icon delete translations-order-delete-entry" title="{{ 'Delete entry'|t }}" data-element="{{element.id}}"><input type="hidden" name="elements[]" value="{{ element.id }}"></a></td>
                             </tr>
                             {% set elementIds = elementIds|merge({(loop.index0):element.id}) %}
                         {% endfor %}

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -617,7 +617,7 @@
                     {{ forms.checkboxSelectField({
                         label: 'Target Site(s)'|t,
                         options: targetSiteCheckboxOptions,
-                        values: order.targetSites,
+                        values: order.targetSites|json_decode(),
                         name: 'targetSites',
                         id: 'targetSites'
                     }) }}

--- a/src/templates/settings/about.twig
+++ b/src/templates/settings/about.twig
@@ -13,8 +13,37 @@
         <h1 style="margin-bottom: 0px;">{{ 'Translations'|t }}</h1>
 
         <h4 style="margin-top: 0px;">{{ 'by Acclaro Inc.'|t }}</h4>
-        
+
+        {% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
+        {% set baseAssetsUrl = craft.app.assetManager.getPublishedUrl(
+            '@acclaro/translations/assetbundles/src', true ) %}
+
         <a href="{{cpUrl('utilities/updates')}}" class="btn submit">{{ 'Check for updates'|t }}</a><br><br>
+
+        <div style="text-align:left;">
+
+            <span style="">
+                <div class="link">
+                    <a href="https://www.surveymonkey.com/r/translationsplugin">
+                        <img src="{{ baseAssetsUrl ~ '/img/feedback-craft-blue.svg' }}" height="25px" style="vertical-align: middle"/> {{ 'Submit Feedback'|t('app') }}
+                    </a>
+
+                    {% set subject = 'Hello Acclaro' %}
+                    {% set body = 'I’m interested in learning more about your professional translation services and how you can help with the launch of global Craft sites.%0D%0A%0D%0AThank you,%0D%0AYour Name%0D%0AYour Company%0D%0AYour Phone Number' %}
+                    <a href="mailto:support@acclaro.com?subject={{subject}}&body={{body}}" style="">
+                        <img src="{{ baseAssetsUrl ~ '/img/translations-craft-blue.svg' }}" height="25px"  style="vertical-align: middle"/> {{ 'Get Translations'|t('app') }}
+                    </a>
+
+                    {% if licenseStatus == 'valid' %}
+                        <a href="https://info.acclaro.com/translation-plugin-for-craft3-support-info">
+                         <img src="{{ baseAssetsUrl ~ '/img/upgrade-craft-blue.svg' }}" height="25px"  style="vertical-align: middle"/>  {{ 'Purchase Premium Support'|t('app') }}  </a>
+                    {% else %}
+                        <a href="https://plugins.craftcms.com/translations">
+                        <img src="{{ baseAssetsUrl ~ '/img/upgrade-craft-blue.svg' }}" height="25px"  style="vertical-align: middle"/> {{ 'Upgrade to Paid'|t('app') }}  </a>
+                    {% endif %}
+                </div>
+            </span>
+        </div>
 
         <div>
             <h3>{{ 'General Information'|t }}</h3>

--- a/src/templates/settings/configuration-options.twig
+++ b/src/templates/settings/configuration-options.twig
@@ -15,7 +15,7 @@
         {{ csrfInput() }}
         {{ forms.hidden({
             name: 'action',
-            value: 'translations/settings/set-settings',
+            value: 'translations/settings/save-configuration-options',
         }) }}
 
         {{ forms.lightswitchField({

--- a/src/templates/settings/setting.twig
+++ b/src/templates/settings/setting.twig
@@ -1,7 +1,7 @@
 {% extends "translations/_layouts/settings" %}
 {% import "_includes/forms" as forms %}
 
-{% set title = 'Settings'|t %}
+{% set title = 'Configuration Options'|t %}
 
 {% block actionButton %}
 <small class="translations-version-header">{{'Version'|t}} {{ craft.app.getPlugins().getPlugin('translations').getVersion() }}</small>
@@ -27,9 +27,17 @@
         }) }}
 
         <div class="buttons">
-            <input type="submit" class="btn submit" value="{{ "Save"|t('app') }}" />
+            <input type="submit" id="save-configuration" class="btn" value="{{ "Save"|t('app') }}" />
         </div>
     </form>
 
 </div>
 {% endblock %}
+
+{% js %}
+    $( document ).ready(function() {
+        $('#chkDuplicateEntries').change(function() {
+            $('#save-configuration').toggleClass('submit');
+        });
+    });
+{% endjs %}

--- a/src/templates/settings/setting.twig
+++ b/src/templates/settings/setting.twig
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="readable">
-    <h2>{{ "Settings"|t('app') }}</h2>
+    <h2>{{ "Configuration Options"|t('app') }}</h2>
 
     <form id="" class="utility" method="post" accept-charset="UTF-8">
         {{ csrfInput() }}

--- a/src/templates/settings/setting.twig
+++ b/src/templates/settings/setting.twig
@@ -1,0 +1,35 @@
+{% extends "translations/_layouts/settings" %}
+{% import "_includes/forms" as forms %}
+
+{% set title = 'Settings'|t %}
+
+{% block actionButton %}
+<small class="translations-version-header">{{'Version'|t}} {{ craft.app.getPlugins().getPlugin('translations').getVersion() }}</small>
+{% endblock %}
+
+{% block content %}
+<div class="readable">
+    <h2>{{ "Settings"|t('app') }}</h2>
+
+    <form id="" class="utility" method="post" accept-charset="UTF-8">
+        {{ csrfInput() }}
+        {{ forms.hidden({
+            name: 'action',
+            value: 'translations/settings/set-settings',
+        }) }}
+
+        {{ forms.lightswitchField({
+            first: true,
+            label: "Show duplicate Entries warnings"|t('app'),
+            id: 'chkDuplicateEntries',
+            name: 'chkDuplicateEntries',
+            on: chkDuplicateEntries,
+        }) }}
+
+        <div class="buttons">
+            <input type="submit" class="btn submit" value="{{ "Save"|t('app') }}" />
+        </div>
+    </form>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
### Added
- Support links to About page
- Setting to disable duplicate message warning
- In Review status to API orders
- User-friendly exported ZIP filenames
- Support for Thai th-TH ISO code

### Updated
- Filenames for API orders to ensure they are unique
- Logic for adding & removing entries from new order screen

### Fixed
- Namespacing issue with static translations
- Craft 3.4+ incompatability with Globals translation drafts
- Resolved issue with pre-selected target sites on previously saved orders
- Redirect for failed orders due to unsupported ISO codes