### PR TITLE
Feature/accl 45 category support

### DIFF
--- a/src/Translations.php
+++ b/src/Translations.php
@@ -72,7 +72,7 @@ class Translations extends Plugin
     /**
      * @var string
      */
-    public $schemaVersion = '1.3.0';
+    public $schemaVersion = '1.3.1';
 
     // Public Methods
     // =========================================================================

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -202,7 +202,8 @@ class Install extends Migration
                 [
                     'id'            => $this->primaryKey(),
                     'name'          => $this->string()->notNull(),
-                    'categoryId'   => $this->integer()->notNull(),
+                    'title'         => $this->string()->notNull(),
+                    'categoryId'    => $this->integer()->notNull(),
                     'site'          => $this->integer()->notNull(),
                     'data'          => $this->mediumText()->notNull(),
                     'dateCreated'   => $this->dateTime()->notNull(),

--- a/src/migrations/m200617_105526_create_category_draft_table.php
+++ b/src/migrations/m200617_105526_create_category_draft_table.php
@@ -23,7 +23,8 @@ class m200617_105526_create_category_draft_table extends Migration
             [
                 'id'            => $this->primaryKey(),
                 'name'          => $this->string()->notNull(),
-                'categoryId'   => $this->integer()->notNull(),
+                'title'         => $this->string()->notNull(),
+                'categoryId'    => $this->integer()->notNull(),
                 'site'          => $this->integer()->notNull(),
                 'data'          => $this->mediumText()->notNull(),
                 'dateCreated'   => $this->dateTime()->notNull(),

--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -33,7 +33,7 @@ class ElementTranslator
         $source = array();
         
         // if ($element instanceof Element || $element instanceof Tag || $element instanceof Category) {
-        if ($element instanceof Element) {
+        if ($element instanceof Element || $element instanceof Category) {
             $source['title'] = $element->title;
             $source['slug'] = $element->slug;
         }

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -123,7 +123,7 @@ class ImportFiles extends BaseJob
                 {
                     if ($draftId === $file->draftId)
                     {	//Get File
-                        $draft_file = Translations::$plugin->fileRepository->getFileByDraftId($draftId);
+                        $draft_file = Translations::$plugin->fileRepository->getFileByDraftId($draftId, $file->elementId);
                     }
                 }
 

--- a/src/services/repository/CategoryDraftRepository.php
+++ b/src/services/repository/CategoryDraftRepository.php
@@ -32,6 +32,7 @@ class CategoryDraftRepository
         $categoryDraft = new CategoryDraftModel($record->toArray([
             'id',
             'name',
+            'title',
             'categoryId',
             'site',
             'data'
@@ -75,6 +76,7 @@ class CategoryDraftRepository
             $categoryDrafts[$key] = new CategoryDraftModel($record->toArray([
                 'id',
                 'name',
+                'title',
                 'categoryId',
                 'site',
                 'data'
@@ -99,6 +101,7 @@ class CategoryDraftRepository
             $record->categoryId = $draft->id;
             $record->site = $draft->site;
             $record->name = $draft->name;
+            $record->title = $draft->title;
         }
 
         return $record;
@@ -127,6 +130,7 @@ class CategoryDraftRepository
         }
         $record->site = $draft->site;
         $record->name = $draft->name;
+        $record->title = $draft->title;
 
         $data = array(
             'fields' => array(),
@@ -138,9 +142,16 @@ class CategoryDraftRepository
         }
         $content = Translations::$plugin->elementTranslator->toPostArray($draft);
 
+        $nestedFieldType = [
+            'craft\fields\Matrix',
+            'verbb\supertable\fields\SuperTableField',
+            'benf\neo\Field'
+        ];
+
         foreach ($draft->getFieldLayout()->getFields() as $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
-            if ($field->getIsTranslatable()) {
+
+            if ($field->getIsTranslatable() || in_array(get_class($field), $nestedFieldType)) {
                 $data['fields'][$field->id] = $content[$field->handle];
                 if (isset($content[$field->handle]) && $content[$field->handle] !== null) { 
                     $data['fields'][$field->id] = $content[$field->handle];

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -103,13 +103,16 @@ class DraftRepository
         return $response;
     }
 
-    public function isTranslationDraft($draftId)
+    public function isTranslationDraft($draftId, $elementId=null)
     {
         $data = [];
 
         $attributes = [
             'draftId' => (int) $draftId
         ];
+        if ($elementId) {
+            $attributes['elementId'] = $elementId;
+        }
 
         $record = FileRecord::findOne($attributes);
 
@@ -248,7 +251,7 @@ class DraftRepository
 
         try {
             // Prevent duplicate files
-            $isExistingFile = $this->isTranslationDraft($draft->draftId);
+            $isExistingFile = $this->isTranslationDraft($draft->draftId, $draft->sourceId);
             if (!empty($isExistingFile)) {
                 return;
             }

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -355,6 +355,7 @@ class DraftRepository
             $draft = Translations::$plugin->categoryDraftRepository->makeNewDraft();
             $draft->name = sprintf('%s [%s]', $orderName, $site);
             $draft->id = $category->id;
+            $draft->title = $category->title;
             $draft->site = $site;
 
             $post = Translations::$plugin->elementTranslator->toPostArray($category);

--- a/src/services/repository/FileRepository.php
+++ b/src/services/repository/FileRepository.php
@@ -54,6 +54,7 @@ class FileRepository
     
     /**
      * @param  int|string $draftId
+     * @param  int|string $elementId
      * @return \acclaro\translations\models\FileModel
      */
     public function getFileByDraftId($draftId, $elementId = null)

--- a/src/services/repository/GlobalSetDraftRepository.php
+++ b/src/services/repository/GlobalSetDraftRepository.php
@@ -134,10 +134,16 @@ class GlobalSetDraftRepository
         );
 
         $content = Translations::$plugin->elementTranslator->toPostArray($draft);
-        
+
+        $nestedFieldType = [
+            'craft\fields\Matrix',
+            'verbb\supertable\fields\SuperTableField',
+            'benf\neo\Field'
+        ];
+
         foreach ($draft->getFieldLayout()->getFields() as $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
-            if ($field->getIsTranslatable()) {
+            if ($field->getIsTranslatable() || in_array(get_class($field), $nestedFieldType)) {
                 $data['fields'][$field->id] = $content[$field->handle];
                 if (isset($content[$field->handle]) && $content[$field->handle] !== null) { 
                     $data['fields'][$field->id] = $content[$field->handle];

--- a/src/services/translator/Export_ImportTranslationService.php
+++ b/src/services/translator/Export_ImportTranslationService.php
@@ -109,7 +109,7 @@ class Export_ImportTranslationService implements TranslationServiceInterface
     {
         $targetData = Translations::$plugin->elementTranslator->getTargetDataFromXml($xml);
 
-        if ($draft instanceof Entry) {
+        if ($draft instanceof Entry || $draft instanceof Category) {
             if (isset($targetData['title'])) {
                 $draft->title = $targetData['title'];
             }

--- a/src/templates/categories/_editDraft.html
+++ b/src/templates/categories/_editDraft.html
@@ -71,7 +71,7 @@
         siteId: category.siteId,
         id: 'title',
         name: 'title',
-        value: category.title,
+        value: draft.title,
         errors: category.getErrors('title'),
         first: true,
         autofocus: true,


### PR DESCRIPTION
### Updates
- Category title is now getting exported and imported properly
- Matrix, Neo, and SuperTable fields now work with Globals and Categories
- Added the title column to the database migration script for Categories
- Increased the schema version to 1.3.1