### PR TITLE
Release/1.8.1

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Easily launch and manage multilingual Craft websites without having to copy/paste content or manually track updates.",
-    "pluginVersion": "1.8.0",
+    "pluginVersion": "1.8.1",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.1 - 2020-08-11
+
+### Added
+- Option to select all sites in target sites selection
+
+### Fixed
+- Unrendered HTML display issue in Craft 3.5+
+- Typecast `$elementId` as an integer for `getElementById()` in `actionOrderDetail()`
+
+### Updated
+- Use the site ID instead of the site handle in `getDraftsByGlobalSetId()`
+
 ## 1.8.0 - 2020-08-06
 
 ### Added

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -473,7 +473,7 @@ class Translations extends Plugin
 
         $drafts = array();
 
-        foreach (self::$plugin->globalSetDraftRepository->getDraftsByGlobalSetId($globalSet->id, $site) as $draft) {
+        foreach (self::$plugin->globalSetDraftRepository->getDraftsByGlobalSetId($globalSet->id, Craft::$app->sites->getSiteByHandle($site)->id) as $draft) {
             $drafts[] = array(
                 'url' => $draft->getCpEditUrl(),
                 'name' => $draft->name,

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -116,7 +116,7 @@ Craft.Translations.OrderDetail = {
                 targetSitesLabels.push(label);
             });
 
-            $('[data-order-attribute=targetSites]').text(targetSitesLabels.join(', '));
+            $('[data-order-attribute=targetSites]').html(targetSitesLabels.join(', '));
         });
 
         $('.translations-order-step-next').on('click', function(e) {

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -471,7 +471,7 @@ class BaseController extends Controller
 
         if ($variables['inputElements']) {
             foreach ($variables['inputElements'] as $elementId) {
-                $element = Craft::$app->getElements()->getElementById($elementId, null, $variables['order']->sourceSite);
+                $element = Craft::$app->getElements()->getElementById((int) $elementId, null, $variables['order']->sourceSite);
 
                 if ($element) {
                     $variables['elements'][] = $element;
@@ -609,7 +609,7 @@ class BaseController extends Controller
             $site = Craft::$app->getSites()->getSiteById($site);
             $variables['targetSiteCheckboxOptions'][] = array(
                 'value' => $site->id,
-                'label' => $site->name. '<span class="light"> ('. $site->language. ')</span>'
+                'label' => $site->name.' ('. $site->language. ')'
             );
         }
 

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -663,6 +663,7 @@
                         label: 'Target Site(s)'|t,
                         options: targetSiteCheckboxOptions,
                         values: order.targetSites|json_decode(),
+                        showAllOption: true,
                         name: 'targetSites',
                         id: 'targetSites'
                     }) }}


### PR DESCRIPTION
### Added
- Option to select all sites in target sites selection

### Fixed
- Unrendered HTML display issue in Craft 3.5+
- Typecast `$elementId` as an integer for `getElementById()` in `actionOrderDetail()`

### Updated
- Use the site ID instead of the site handle in `getDraftsByGlobalSetId()`