### PR TITLE
Failed file if resnames within the target file don't match

### DIFF
--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -143,6 +143,8 @@ class ImportFiles extends BaseJob
             if($this->checkResname($dom, $draft_file)){
                 $this->order->logActivity(Translations::$plugin->translator->translate('app', "File failed to import due to the resname mismatches in the XML."));
                 Translations::$plugin->orderRepository->saveOrder($this->order);
+                $draft_file->status = 'failed';
+                Translations::$plugin->fileRepository->saveFile($draft_file);
                 return;
             }
 


### PR DESCRIPTION
- Explicitly fail files if `resnameCheck()` fails