### PR TITLE
Release/1.9.4

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Easily launch and manage multilingual Craft websites without having to copy/paste content or manually track updates.",
-    "pluginVersion": "1.9.3",
+    "pluginVersion": "1.9.4",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.9.4 - 2021-01-18
+
+## Added
+- Custom Twig RegEx Filters for Static Translations https://github.com/AcclaroInc/craft-translations/pull/130
+- Spinner icon to individual "Apply Translation" buttons https://github.com/AcclaroInc/craft-translations/pull/131
+- `zh-Hans-CN` mapping to `SiteRepository.php` https://github.com/AcclaroInc/craft-translations/commit/acfc84dde21318bfb04a4e8970680aed12021699
+
+### Fixed
+- [BUG] - Target Site draft preview URI structures https://github.com/AcclaroInc/craft-translations/commit/be7bbe219730e5586477729996c1c5ecad84055d
+- [BUG] - Disable the "Publish Changes" button within Entry detail screen https://github.com/AcclaroInc/craft-translations/pull/129
+- [BUG] - Order status not updating to "Applied" https://github.com/AcclaroInc/craft-translations/pull/128
+
 ## 1.9.3 - 2020-12-16
 
 ### Fixed

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -563,9 +563,6 @@ class Translations extends Plugin
 
                     $currentFile->status = 'canceled';
 
-                    $element = Craft::$app->getElements()->getElementById($currentFile->elementId, null, $currentFile->targetSite);
-                    $currentFile->previewUrl = Translations::$plugin->urlGenerator->generateElementPreviewUrl($element, $currentFile->targetSite);
-
                     $element = Craft::$app->getElements()->getElementById($currentFile->elementId, null, $currentFile->sourceSite);
                     $currentFile->previewUrl = Translations::$plugin->urlGenerator->generateElementPreviewUrl($element, $currentFile->targetSite);
                     $currentFile->source = Translations::$plugin->elementToXmlConverter->toXml(

--- a/src/assetbundles/src/js/ApplyTranslations.js
+++ b/src/assetbundles/src/js/ApplyTranslations.js
@@ -8,8 +8,8 @@ Craft.Translations.ApplyTranslations = {
     init: function(draftId, file) {
         // Disable default Craft updating
         window.draftEditor.settings.canUpdateSource = false;
-        $("#main-form input[type='submit']").disable();
-        $("#main-form input[type='submit']").attr('disabled', true);
+        $("#publish-changes-btn-container :input[type='button']").disable();
+        $("#publish-changes-btn-container :input[type='button']").attr('disabled', true);
         
         // Create the Apply Translations button
         var $applyTranslationsContainer = document.createElement('div');

--- a/src/assetbundles/src/js/ApplyTranslations.js
+++ b/src/assetbundles/src/js/ApplyTranslations.js
@@ -46,13 +46,18 @@ Craft.Translations.ApplyTranslations = {
             // reactivate the button
             $(this.$btn).enable();
             $(this.$btn).attr('disabled', false);
-            $(this.$btn).on("click", function (e) {
+
+            $(this.$btn).one("click", function (e) {
                 e.preventDefault();
+                $(".apply-translations > a").addClass("disabled");
+                $(".apply-translations > a").html("");
+                $(".apply-translations .submit").width(122);
+                $(".apply-translations > a").toggleClass("spinner");
                 
                 var fileData = {
                     fileId: file.id,
                 };
-
+                
                 Craft.postActionRequest('translations/files/apply-translation-draft', fileData, function(response, textStatus) {
                     if (textStatus === 'success' && response.success) {
                         console.log(response.data);

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -363,6 +363,14 @@ Craft.Translations.OrderDetail = {
                         // Add the diff html
                         document.getElementById("modal-body-entry").innerHTML = diffHtml;
 
+                        $('#apply-translation').one('click', function(e) {
+                            $(".apply-translation").addClass("disabled");
+                            $(".apply-translation").prop("value", "");
+                            $(".apply-translation").css('margin-right', 4);
+                            $(".apply-translation").width(110);
+                            $(".apply-translation").toggleClass("spinner");
+                        });
+
                         $('#close-diff-modal-entry').on('click', function(e) {
                             e.preventDefault();
                             modal.hide();

--- a/src/assetbundles/src/js/OrderEntries.js
+++ b/src/assetbundles/src/js/OrderEntries.js
@@ -46,6 +46,12 @@ Craft.Translations.OrderEntries = {
             Craft.Translations.OrderEntries.togglePublishButton();
             Craft.Translations.OrderEntries.toggleSelectAllCheckbox();
         });
+        this.$publishSelectedBtn.one('click', function (e) {
+            $(".translations-publish-selected-btn").addClass("disabled");
+            $(".translations-publish-selected-btn").prop("value", "");
+            $(".translations-publish-selected-btn").width(160);
+            $(".translations-publish-selected-btn").toggleClass("spinner");
+        });
     }
 };
 

--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -468,13 +468,10 @@ class FilesController extends Controller
         $publishedFilesCount = 0;
 
         foreach ($files as $key => $f) {
-            if ($f->status !== 'complete') {
-                continue;
+            if ($f->status === 'published') {
+                $publishedFilesCount++;
             }
-            
-            $publishedFilesCount++;
         }
-
 
         if ($publishedFilesCount === $filesCount) {
             $order->status = 'published';

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -235,6 +235,8 @@ class SettingsController extends Controller
 
         $variables['chkDuplicateEntries'] = Translations::getInstance()->settings->chkDuplicateEntries;
         $variables['uploadVolume'] = Translations::getInstance()->settings->uploadVolume;
+        $variables['twigSearchFilterSingleQuote'] = !empty(Translations::getInstance()->settings->twigSearchFilterSingleQuote) ? Translations::getInstance()->settings->twigSearchFilterSingleQuote : "";
+        $variables['twigSearchFilterDoubleQuote'] = !empty(Translations::getInstance()->settings->twigSearchFilterDoubleQuote) ? Translations::getInstance()->settings->twigSearchFilterDoubleQuote : "";
 
         $allVolumes = Craft::$app->getVolumes()->getAllVolumes();
 
@@ -264,12 +266,14 @@ class SettingsController extends Controller
         $request = Craft::$app->getRequest();
         $duplicateEntries = $request->getParam('chkDuplicateEntries');
         $selectedVolume = $request->getParam('uploadVolume');
+        $twigSearchFilterSingleQuote = $request->getParam('twigSearchFilterSingleQuote');
+        $twigSearchFilterDoubleQuote = $request->getParam('twigSearchFilterDoubleQuote');
 
         try {
 
             $pluginService = Craft::$app->getPlugins();
             $plugin  = $pluginService->getPlugin('translations');
-            if (!$pluginService->savePluginSettings($plugin, ['chkDuplicateEntries' => $duplicateEntries, 'uploadVolume' => $selectedVolume])) {
+            if (!$pluginService->savePluginSettings($plugin, ['chkDuplicateEntries' => $duplicateEntries, 'uploadVolume' => $selectedVolume, 'twigSearchFilterSingleQuote' => $twigSearchFilterSingleQuote, 'twigSearchFilterDoubleQuote' => $twigSearchFilterDoubleQuote])) {
                 Craft::$app->getSession()->setError(Translations::$plugin->translator->translate('app', 'Unable to save setting.'));
             } else {
                 Craft::$app->getSession()->setNotice(Translations::$plugin->translator->translate('app', 'Setting saved.'));

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -233,10 +233,12 @@ class SettingsController extends Controller
             return;
         }
 
-        $variables['chkDuplicateEntries'] = Translations::getInstance()->settings->chkDuplicateEntries;
-        $variables['uploadVolume'] = Translations::getInstance()->settings->uploadVolume;
-        $variables['twigSearchFilterSingleQuote'] = !empty(Translations::getInstance()->settings->twigSearchFilterSingleQuote) ? Translations::getInstance()->settings->twigSearchFilterSingleQuote : "";
-        $variables['twigSearchFilterDoubleQuote'] = !empty(Translations::getInstance()->settings->twigSearchFilterDoubleQuote) ? Translations::getInstance()->settings->twigSearchFilterDoubleQuote : "";
+        $settings = Translations::getInstance()->settings;
+        $variables['chkDuplicateEntries'] = $settings->chkDuplicateEntries;
+        $variables['uploadVolume'] = $settings->uploadVolume;
+        $variables['twigSearchFilterSingleQuote'] = !empty($settings->twigSearchFilterSingleQuote) ? $settings->twigSearchFilterSingleQuote : "";
+        $variables['twigSearchFilterDoubleQuote'] = !empty($settings->twigSearchFilterDoubleQuote) ? $settings->twigSearchFilterDoubleQuote : "";
+        $variables['targetStringPosition'] = !empty($settings->targetStringPosition) ? $settings->targetStringPosition : "";
 
         $allVolumes = Craft::$app->getVolumes()->getAllVolumes();
 
@@ -268,12 +270,13 @@ class SettingsController extends Controller
         $selectedVolume = $request->getParam('uploadVolume');
         $twigSearchFilterSingleQuote = $request->getParam('twigSearchFilterSingleQuote');
         $twigSearchFilterDoubleQuote = $request->getParam('twigSearchFilterDoubleQuote');
+        $targetStringPosition = $request->getParam('targetStringPosition');
 
         try {
 
             $pluginService = Craft::$app->getPlugins();
             $plugin  = $pluginService->getPlugin('translations');
-            if (!$pluginService->savePluginSettings($plugin, ['chkDuplicateEntries' => $duplicateEntries, 'uploadVolume' => $selectedVolume, 'twigSearchFilterSingleQuote' => $twigSearchFilterSingleQuote, 'twigSearchFilterDoubleQuote' => $twigSearchFilterDoubleQuote])) {
+            if (!$pluginService->savePluginSettings($plugin, ['chkDuplicateEntries' => $duplicateEntries, 'uploadVolume' => $selectedVolume, 'twigSearchFilterSingleQuote' => $twigSearchFilterSingleQuote, 'twigSearchFilterDoubleQuote' => $twigSearchFilterDoubleQuote, 'targetStringPosition' => $targetStringPosition])) {
                 Craft::$app->getSession()->setError(Translations::$plugin->translator->translate('app', 'Unable to save setting.'));
             } else {
                 Craft::$app->getSession()->setNotice(Translations::$plugin->translator->translate('app', 'Setting saved.'));

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -26,6 +26,10 @@ class Settings extends Model
 {
     public $chkDuplicateEntries = true;
 
+    public $twigSearchFilterSingleQuote = "";
+
+    public $twigSearchFilterDoubleQuote = "";
+
     /** @var int The Volume ID where uploads will be saved */
     public $uploadVolume = 0;
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -30,6 +30,8 @@ class Settings extends Model
 
     public $twigSearchFilterDoubleQuote = "";
 
+    public $targetStringPosition = "";
+
     /** @var int The Volume ID where uploads will be saved */
     public $uploadVolume = 0;
 

--- a/src/services/ElementToXmlConverter.php
+++ b/src/services/ElementToXmlConverter.php
@@ -36,7 +36,7 @@ class ElementToXmlConverter
         $sites->setAttribute('target-site', $targetSite);
         $langs->setAttribute('source-language', Craft::$app->sites->getSiteById($sourceSite)->language);
         $langs->setAttribute('target-language', (Craft::$app->sites->getSiteById($targetSite)) ? Craft::$app->sites->getSiteById($targetSite)->language : 'deleted');
-        $original->setAttribute('url', Translations::$plugin->urlGenerator->generateElementPreviewUrl($element, $targetSite));
+        $original->setAttribute('url', Translations::$plugin->urlGenerator->generateElementPreviewUrl($element));
         $preview->setAttribute('url', $previewUrl);
 
         $elementIdMeta = $head->appendChild($dom->createElement('meta'));

--- a/src/services/UrlGenerator.php
+++ b/src/services/UrlGenerator.php
@@ -106,7 +106,7 @@ class UrlGenerator
         return Translations::$plugin->urlHelper->cpUrl($path);
     }
     
-    public function generateElementPreviewUrl(Element $element, $targetSite)
+    public function generateElementPreviewUrl(Element $element, $siteId)
     {
         $params = array();
         
@@ -123,7 +123,7 @@ class UrlGenerator
                 'preview/preview', [
                     'elementType' => $className,
                     'sourceId' => $element->sourceId,
-                    'siteId' => $element->siteId,
+                    'siteId' => $siteId ? $siteId : $element->siteId,
                     'draftId' => $element->draftId,
                     'revisionId' => $element->revisionId
                 ]

--- a/src/services/UrlGenerator.php
+++ b/src/services/UrlGenerator.php
@@ -106,7 +106,7 @@ class UrlGenerator
         return Translations::$plugin->urlHelper->cpUrl($path);
     }
     
-    public function generateElementPreviewUrl(Element $element, $siteId)
+    public function generateElementPreviewUrl(Element $element, $siteId = null)
     {
         $params = array();
         
@@ -119,6 +119,8 @@ class UrlGenerator
         if ($className === Entry::class && !$element->getIsDraft()) {
             $previewUrl = $element->getUrl();
         } else {
+            $element = Craft::$app->getElements()->getElementById($element->sourceId, null, $siteId);
+
             $route = [
                 'preview/preview', [
                     'elementType' => $className,
@@ -142,7 +144,7 @@ class UrlGenerator
                 $previewUrl = '';
             }
         }
-        
+
         return $previewUrl;
     }
 }

--- a/src/services/repository/SiteRepository.php
+++ b/src/services/repository/SiteRepository.php
@@ -127,6 +127,7 @@ class SiteRepository
         'zh-tw' => 'zh-TW',          //Chinese (Traditional)
         'zh-hans' => 'zh-CN',        //Chinese (Simplified)
         'zh-hant' => 'zh-TW',        //Chinese (Traditional)
+        'zh-hans-cn' => 'zh-CN',     //Chinese (Simplified)
         'nl-nl' => 'nl',             //Dutch (Netherlands)
         'da-dk' => 'da',             //Danish (Denmark)
         'en' => 'en-us',             //English

--- a/src/services/repository/StaticTranslationsRepository.php
+++ b/src/services/repository/StaticTranslationsRepository.php
@@ -14,6 +14,7 @@ use Craft;
 use Exception;
 use craft\helpers\FileHelper;
 use craft\helpers\ElementHelper;
+use acclaro\translations\Translations;
 use craft\elements\db\ElementQueryInterface;
 use acclaro\translations\elements\StaticTranslations;
 
@@ -137,7 +138,8 @@ class StaticTranslationsRepository
      * @return array
      */
     public function getExpressions($ext) {
-
+        $twigSearchFilterSingleQuote = !empty(Translations::getInstance()->settings->twigSearchFilterSingleQuote) ? Translations::getInstance()->settings->twigSearchFilterSingleQuote : '/\'((?:[^\']|\\\\\')*)\'\s*\|\s*t(?:ranslate)?\b/';
+        $twigSearchFilterDoubleQuote = !empty(Translations::getInstance()->settings->twigSearchFilterDoubleQuote) ? Translations::getInstance()->settings->twigSearchFilterDoubleQuote : '/"((?:[^"]|\\\\")*)"\s*\|\s*t(?:ranslate)?\b/';
         $exp = [];
         switch ($ext) {
             case 'php':
@@ -156,8 +158,7 @@ class StaticTranslationsRepository
                 $exp = [
                     'position' => '1',
                     'regex' => [
-                        '/\'((?:[^\']|\\\\\')*)\'\s*\|\s*t(?:ranslate)?\b/',
-                        '/"((?:[^"]|\\\\")*)"\s*\|\s*t(?:ranslate)?\b/',
+                        $twigSearchFilterSingleQuote, $twigSearchFilterDoubleQuote
                     ]
                 ];
                 break;

--- a/src/services/repository/StaticTranslationsRepository.php
+++ b/src/services/repository/StaticTranslationsRepository.php
@@ -138,8 +138,17 @@ class StaticTranslationsRepository
      * @return array
      */
     public function getExpressions($ext) {
-        $twigSearchFilterSingleQuote = !empty(Translations::getInstance()->settings->twigSearchFilterSingleQuote) ? Translations::getInstance()->settings->twigSearchFilterSingleQuote : '/\'((?:[^\']|\\\\\')*)\'\s*\|\s*t(?:ranslate)?\b/';
-        $twigSearchFilterDoubleQuote = !empty(Translations::getInstance()->settings->twigSearchFilterDoubleQuote) ? Translations::getInstance()->settings->twigSearchFilterDoubleQuote : '/"((?:[^"]|\\\\")*)"\s*\|\s*t(?:ranslate)?\b/';
+        $settings = Translations::getInstance()->settings;
+        if(!empty($settings->twigSearchFilterSingleQuote)) {
+            $twigSearchFilterSingleQuote = $settings->twigSearchFilterSingleQuote;
+            $twigSearchFilterDoubleQuote = $settings->twigSearchFilterDoubleQuote;
+            $targetStringPosition = $settings->targetStringPosition;
+        } else {
+            $twigSearchFilterSingleQuote = '/\'((?:[^\']|\\\\\')*)\'\s*\|\s*t(?:ranslate)?\b/';
+            $twigSearchFilterDoubleQuote = '/"((?:[^"]|\\\\")*)"\s*\|\s*t(?:ranslate)?\b/';
+            $targetStringPosition = 1;
+        }
+
         $exp = [];
         switch ($ext) {
             case 'php':
@@ -156,7 +165,7 @@ class StaticTranslationsRepository
             case 'atom':
             case 'rss':
                 $exp = [
-                    'position' => '1',
+                    'position' => $targetStringPosition,
                     'regex' => [
                         $twigSearchFilterSingleQuote, $twigSearchFilterDoubleQuote
                     ]

--- a/src/templates/settings/configuration-options.twig
+++ b/src/templates/settings/configuration-options.twig
@@ -36,6 +36,24 @@
             toggle: true
         }) }}
 
+        <h3>{{ "Static Translations"|t('app') }}</h3>
+
+        {{ forms.textField({
+            label: "Twig search filter (single quote)"|t('app'),
+            id: 'twigSearchFilterSingleQuote',
+            name: 'twigSearchFilterSingleQuote',
+            value: twigSearchFilterSingleQuote ?? '',
+            size: '40',
+        }) }}
+        
+        {{ forms.textField({
+            label: "Twig search filter (double quote)"|t('app'),
+            id: 'twigSearchFilterDoubleQuote',
+            name: 'twigSearchFilterDoubleQuote',
+            value: twigSearchFilterDoubleQuote ?? '',
+            size: '40',
+        }) }}
+
         <div class="buttons">
             <input type="submit" id="save-configuration" class="btn" value="{{ "Save"|t('app') }}" />
         </div>

--- a/src/templates/settings/configuration-options.twig
+++ b/src/templates/settings/configuration-options.twig
@@ -40,6 +40,7 @@
 
         {{ forms.textField({
             label: "Twig search filter (single quote)"|t('app'),
+            placeholder: "Twig search filter (single quote)"|t('app'),
             id: 'twigSearchFilterSingleQuote',
             name: 'twigSearchFilterSingleQuote',
             value: twigSearchFilterSingleQuote ?? '',
@@ -48,9 +49,19 @@
         
         {{ forms.textField({
             label: "Twig search filter (double quote)"|t('app'),
+            placeholder: "Twig search filter (double quote)"|t('app'),
             id: 'twigSearchFilterDoubleQuote',
             name: 'twigSearchFilterDoubleQuote',
             value: twigSearchFilterDoubleQuote ?? '',
+            size: '40',
+        }) }}
+
+        {{ forms.textField({
+            label: "Target String Position"|t('app'),
+            placeholder: "Target String Position"|t('app'),
+            id: 'targetStringPosition',
+            name: 'targetStringPosition',
+            value: targetStringPosition ?? '',
             size: '40',
         }) }}
 


### PR DESCRIPTION
## 1.9.4 - 2021-01-18

## Added
- Custom Twig RegEx Filters for Static Translations https://github.com/AcclaroInc/craft-translations/pull/130
- Spinner icon to individual "Apply Translation" buttons https://github.com/AcclaroInc/craft-translations/pull/131
- `zh-Hans-CN` mapping to `SiteRepository.php` https://github.com/AcclaroInc/craft-translations/commit/acfc84dde21318bfb04a4e8970680aed12021699

### Fixed
- [BUG] - Target Site draft preview URI structures https://github.com/AcclaroInc/craft-translations/commit/be7bbe219730e5586477729996c1c5ecad84055d
- [BUG] - Disable the "Publish Changes" button within Entry detail screen https://github.com/AcclaroInc/craft-translations/pull/129
- [BUG] - Order status not updating to "Applied" https://github.com/AcclaroInc/craft-translations/pull/128