### PR TITLE
Release/1.10.0

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Discord Notification
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  notify:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: binotaliu/action-discord-notifier@v1
+        with:
+          message-title: New Deploy for Craft Translations
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.5.9",
+        "craftcms/cms": "^3.6.0",
         "guzzlehttp/guzzle": "^6.3",
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "sebastian/diff": "^3.0"
     },
     "autoload": {

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -113,31 +113,31 @@ class Translations extends Plugin
 
         Event::on(
             Drafts::class,
-            Drafts::EVENT_BEFORE_APPLY_DRAFT,
+            Drafts::EVENT_BEFORE_PUBLISH_DRAFT,
             function (DraftEvent $event) {
                 // Craft::debug(
-                //     'Drafts::EVENT_BEFORE_APPLY_DRAFT',
+                //     'Drafts::EVENT_BEFORE_PUBLISH_DRAFT',
                 //     __METHOD__
                 // );
                 Craft::info(
                     Craft::t(
                         'translations',
-                        '{name} Drafts::EVENT_BEFORE_APPLY_DRAFT',
+                        '{name} Drafts::EVENT_BEFORE_PUBLISH_DRAFT',
                         ['name' => $this->name]
                     ),
                     'translations'
                 );
 
-                $this->_onSaveEntry($event);
+                $this->_onBeforePublishDraft($event);
             }
         );
         
         Event::on(
             Drafts::class,
-            Drafts::EVENT_AFTER_APPLY_DRAFT,
+            Drafts::EVENT_AFTER_PUBLISH_DRAFT,
             function (DraftEvent $event) {
                 Craft::debug(
-                    '['. __METHOD__ .'] Drafts::EVENT_AFTER_APPLY_DRAFT',
+                    '['. __METHOD__ .'] Drafts::EVENT_AFTER_PUBLISH_DRAFT',
                     'translations'
                 );
                 if ($event->draft) {
@@ -510,6 +510,35 @@ class Translations extends Plugin
     {
         // @TODO check if entry is part of an in-progress translation order
         // and send notification to acclaro
+    }
+
+    private function _onBeforePublishDraft(Event $event)
+    {
+        $craft = Craft::$app;
+        $request = $craft->getRequest();
+
+        $draft = $event->draft;
+
+        $draftId = isset($draft['draftId']) ? $draft['draftId'] : '';
+
+        $response = Translations::$plugin->draftRepository->isTranslationDraft($draftId);
+
+        $action = $request->getActionSegments();
+        $action = end($action);
+
+        $applyDraftActions = [
+            'apply-drafts',
+            'apply-translation-draft',
+        ];
+
+        if(!empty($response) && !in_array($action, $applyDraftActions)) {
+
+            Craft::$app->getSession()->setError(Translations::$plugin->translator->translate('app', 'Unable to publish translation draft.'));
+            $path = $craft->request->getFullPath();
+            $params = $craft->request->getQueryParams();
+            $craft->response->redirect(UrlHelper::siteUrl($path, $params))->send();
+            $craft->end();
+        }
     }
 
     private function _onApplyDraft(Event $event)

--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -707,3 +707,37 @@ del {
 .static-trans-footer .pagination {
     display: none;
 }
+
+.footer-order-navigation{
+    background-color: #f3f7fc;
+    border-radius: 0 0 5px 5px;
+    display: flex;
+    justify-content: space-between;
+    margin: 0px -24px -24px -24px;
+    padding: 10px 24px;
+}
+
+.top-order-navigation{
+    background-color: #f3f7fc;
+    border-radius: 5px 5px 0 0;
+    display: flex;
+    justify-content: space-between;
+    margin: -24px -24px 20px -24px;
+    padding: 10px 24px;
+}
+
+.top-order-navigation span,
+.footer-order-navigation span{
+    margin: 0px 10px;
+}
+
+.footer-order-navigation a,
+.top-order-navigation a{
+    color: #606d7b;
+    transition: color linear 100ms;
+}
+
+.footer-order-navigation a:hover,
+.top-order-navigation a:hover{
+    color: #0B69A3;
+}

--- a/src/assetbundles/src/js/ApplyTranslations.js
+++ b/src/assetbundles/src/js/ApplyTranslations.js
@@ -10,6 +10,9 @@ Craft.Translations.ApplyTranslations = {
         window.draftEditor.settings.canUpdateSource = false;
         $("#publish-changes-btn-container :input[type='button']").disable();
         $("#publish-changes-btn-container :input[type='button']").attr('disabled', true);
+
+        $("#publish-draft-btn-container :input[type='button']").disable();
+        $("#publish-draft-btn-container :input[type='button']").attr('disabled', true);
         
         // Create the Apply Translations button
         var $applyTranslationsContainer = document.createElement('div');

--- a/src/assetbundles/src/js/OrderDetail.js
+++ b/src/assetbundles/src/js/OrderDetail.js
@@ -163,11 +163,11 @@ Craft.Translations.OrderDetail = {
 
                 $('[data-order-attribute=wordCount]').text(wordCount);
 
-                var param = window.location.search;
-                param = param.replace("&elements[]="+$button.attr('data-element'), "");
-                param = 'admin/translations/orders/new'+param;
+                // var param = window.location.search;
+                // param = param.replace("&elements[]="+$button.attr('data-element'), "");
+                // param = 'admin/translations/orders/new'+param;
 
-                window.history.pushState("object or string", "Translations", "/"+param);
+                // window.history.pushState("object or string", "Translations", "/"+param);
                 var currentElementIds = $('#currentElementIds').val();
                 currentElementIds = currentElementIds.replace($button.attr('data-element'), '').replace(',,', ',');
                 $('#currentElementIds').val(currentElementIds);
@@ -433,6 +433,15 @@ Craft.Translations.OrderDetail = {
         }
 
         $(".addEntries").on('click', function (e) {
+            var current_url = window.location.href;
+            if(current_url.includes('/admin/translations/orders/detail/'))
+            {
+                if(current_url.includes('?')) {
+                    current_url = current_url.split('?')[0];
+                }
+                $('#addNewEntries').val(0);
+            }
+
             elementIds = currentElementIds = [];
 
             var sourceSites = [];
@@ -478,10 +487,17 @@ Craft.Translations.OrderDetail = {
                                 elementUrl += '&elements[]='+currentElementIds[i];
                             }
                         }
+                        
                         if ($('#addNewEntries').val() == 1) {
                             window.location.href=Craft.getUrl('translations/orders/new')+'?sourceSite='+site+elementUrl;
                         } else {
-                            addEntries();
+                            if($('#addNewEntries').val() == 0) {
+                                var orderId = current_url.split('/admin/translations/orders/detail/')[1];
+                                window.location.href = current_url+'?orderId='+orderId;
+                                addEntries(null, orderId);
+                            } else {
+                                addEntries();
+                            }
 
                             setTimeout(function(){ $('#content').removeClass('elements busy') }, 5000);
                         }
@@ -495,9 +511,12 @@ Craft.Translations.OrderDetail = {
 
         });
 
-        function addEntries(skipOrReplace=null) {
+        function addEntries(skipOrReplace=null, order_id = null) {
 
-            var order_id = $('#order_id').val();
+            if(order_id == null) {
+                order_id = $('#order_id').val();
+            }
+
             var checkDuplicate = $('#checkDuplicate').val();
             var post_data = {
                 action: 'translations/base/add-entries',

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -443,7 +443,14 @@ class BaseController extends Controller
             if (!$variables['order']) {
                 throw new HttpException(404);
             }
-           
+
+            $orders = Translations::$plugin->orderRepository->getAllOrderIds();
+            $key = array_search($variables['orderId'], $orders);
+            if($key !== false) {
+                $variables['previous_order'] = ($key > 0) ? Translations::$plugin->urlGenerator->generateCpUrl('admin/translations/orders/detail/'.$orders[$key-1]) : '';
+                $variables['next_order'] = ($key < count($orders)-1) ? Translations::$plugin->urlGenerator->generateCpUrl('admin/translations/orders/detail/'.$orders[$key+1]) : '';
+            }
+
         } else {
             $variables['order'] = Translations::$plugin->orderRepository->makeNewOrder($variables['inputSourceSite']);
 
@@ -865,6 +872,12 @@ class BaseController extends Controller
 
             if ($targetSites === '*') {
                 $targetSites = Craft::$app->getSites()->getAllSiteIds();
+                
+                $source_site = Craft::$app->getRequest()->getParam('sourceSite');
+                if (($key = array_search($source_site, $targetSites)) !== false) {
+                    unset($targetSites[$key]);
+                    $targetSites = array_values($targetSites);
+                }
             }
 
             $requestedDueDate = Craft::$app->getRequest()->getParam('requestedDueDate');
@@ -1245,10 +1258,11 @@ class BaseController extends Controller
             ]);
         }
 
-        /*if ($order->getTranslator()->service == 'acclaro') {
+        if ($order->getTranslator()->service == 'acclaro') {
             $translationService = Translations::$plugin->translatorFactory->makeTranslationService($order->getTranslator()->service, $order->getTranslator()->getSettings());
             $res = $translationService->editOrderName($order->serviceOrderId, $name);
-        }*/
+            
+        }
 
         $translationService = Translations::$plugin->translatorFactory->makeTranslationService('export_import', $order->getTranslator()->getSettings());
         $res = $translationService->editOrderName($order, $name);

--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -109,7 +109,7 @@ class FilesController extends Controller
 
                 if ($element instanceof GlobalSet)
                 {
-                    $filename = $file->elementId . '-' . ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                    $filename = $file->elementId . '-' . ElementHelper::normalizeSlug($element->name).'-'.$targetSite.'.xml';
                 } else
                 {
                     $filename = $file->elementId . '-' . $element->slug.'-'.$targetSite.'.xml';

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -70,7 +70,14 @@ class SettingsController extends Controller
             'luwes\codemirror\fields\CodeMirrorField',
             'verbb\supertable\fields\SuperTableField',
             'nystudio107\seomatic\fields\SeoSettings',
-            'lenz\linkfield\fields\LinkField'
+            'lenz\linkfield\fields\LinkField',
+            'newism\fields\fields\Telephone',
+            'newism\fields\fields\Address',
+            'newism\fields\fields\Email',
+            'newism\fields\fields\Embed',
+            'newism\fields\fields\PersonName',
+            'newism\fields\fields\Gender',
+            'ether\seo\fields\SeoField'
         ];
 
         $unrelatedFieldTypes = [

--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -42,14 +42,14 @@ class ElementTranslator
             }
 
         }
-        
+
         foreach ($element->getFieldLayout()->getFields() as $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
             $fieldSource = $this->fieldToTranslationSource($element, $field, $sourceSite);
 
             $source = array_merge($source, $fieldSource);
         }
-
+        
         return $source;
     }
 
@@ -94,16 +94,16 @@ class ElementTranslator
     public function toPostArrayFromTranslationTarget(Element $element, $sourceSite, $targetSite, $targetData, $includeNonTranslatable = false)
     {
         $post = array();
-        
+
         foreach($element->getFieldLayout()->getFields() as $key => $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
-            
+
             $fieldHandle = $field->handle;
             
             $fieldType = $field;
             
             $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($fieldType);
-            
+
             if (!$translator) {
                 if ($includeNonTranslatable) {
                     $post[$fieldHandle] = $element->$fieldHandle;
@@ -112,13 +112,13 @@ class ElementTranslator
                 continue;
             }
 
-            
+            $fieldPost = [];
             if (isset($targetData[$fieldHandle])) {
-                $fieldPost = $translator->toPostArrayFromTranslationTarget($this, $element, $field, $sourceSite, $targetSite, $targetData[$fieldHandle]);
+                    $fieldPost = $translator->toPostArrayFromTranslationTarget($this, $element, $field, $sourceSite, $targetSite, $targetData[$fieldHandle]);
             } else {
                 $fieldPost = $translator->toPostArray($this, $element, $field, $sourceSite);
             }
-            
+
             
             if (!is_array($fieldPost)) {
                 $fieldPost = array($fieldHandle => $fieldPost);
@@ -126,11 +126,13 @@ class ElementTranslator
             
             $post = array_merge($post, $fieldPost);
         }
-        
+
         // echo '<pre>';
-        // echo "//======================================================================<br>// post toPostArrayFromTranslationTarget()<br>//======================================================================<br>";
+        // echo "//======================================================================<br>// post ElementTranslator<br>//======================================================================<br>";
         // var_dump($post);
         // echo '</pre>';
+        // die;
+
         return $post;
     }
 

--- a/src/services/UrlGenerator.php
+++ b/src/services/UrlGenerator.php
@@ -119,8 +119,6 @@ class UrlGenerator
         if ($className === Entry::class && !$element->getIsDraft()) {
             $previewUrl = $element->getUrl();
         } else {
-            $element = Craft::$app->getElements()->getElementById($element->sourceId, null, $siteId);
-
             $route = [
                 'preview/preview', [
                     'elementType' => $className,

--- a/src/services/api/AcclaroApiClient.php
+++ b/src/services/api/AcclaroApiClient.php
@@ -17,6 +17,8 @@ class AcclaroApiClient
 
     const SANDBOX_URL = 'https://apisandbox.acclaro.com/api2/';
 
+    const DELIVERY = 'craftcms';
+
     protected $loggingEnabled = false;
 
     public function __construct(
@@ -174,7 +176,7 @@ class AcclaroApiClient
             'comments' => $comments,
             'duedate' => $dueDate,
             // 'clientref' => $craftOrderId,
-            'delivery' => 'none',
+            'delivery' => self::DELIVERY,
             'estwordcount' => $wordCount,
         ));
     }
@@ -311,10 +313,10 @@ class AcclaroApiClient
 
     public function editOrderName($orderId, $name)
     {
-
         return $this->post('EditOrder', array(
-            'OrderID' => $orderId,
-            'Name' => $name,
+            'orderid' => $orderId,
+            'name' => $name,
+            'delivery' => self::DELIVERY,
         ));
     }
 }

--- a/src/services/fieldtranslator/Factory.php
+++ b/src/services/fieldtranslator/Factory.php
@@ -25,7 +25,16 @@ use craft\fields\Checkboxes;
 use craft\fields\MultiSelect;
 use craft\fields\RadioButtons;
 
+use newism\fields\fields\Address;
+use newism\fields\fields\Email;
+use newism\fields\fields\Embed;
+use newism\fields\fields\Gender;
+use newism\fields\fields\PersonName;
+use newism\fields\fields\Telephone;
+use newism\fields\NsmFields;
+
 use benf\neo\Field as NeoField;
+use ether\seo\fields\SeoField;
 use typedlinkfield\fields\LinkField as LinkField;
 use lenz\linkfield\fields\LinkField as TypedLinkField;
 use craft\redactor\Field as RedactorField;
@@ -56,10 +65,17 @@ class Factory
         RadioButtons::class     => SingleOptionFieldTranslator::class,
         RedactorField::class    => GenericFieldTranslator::class,
         SeoSettings::class      => SeomaticMetaFieldTranslator::class,
+        SeoField::class         => SeoFieldTranslator::class,
         SuperTableField::class  => SuperTableFieldTranslator::class,
         Table::class            => TableFieldTranslator::class,
         Tags::class             => TagFieldTranslator::class,
         CodeMirrorField::class  => GenericFieldTranslator::class,
+        PersonName::class       => NsmFieldsTranslator::class,
+        Address::class          => NsmFieldsTranslator::class,
+        Email::class            => NsmFieldsTranslator::class,
+        Telephone::class        => NsmFieldsTranslator::class,
+        Gender::class           => NsmFieldsTranslator::class,
+        Embed::class            => NsmFieldsTranslator::class,
     );
 
     public function makeTranslator(Field $field)
@@ -67,9 +83,9 @@ class Factory
         if ($field instanceof TranslatableFieldInterface) {
             return $field;
         }
-        
+
         $class = get_class($field);
-        
+
         if (array_key_exists($class, $this->nativeFieldTypes)) {
             $translatorClass = $this->nativeFieldTypes[$class];
 

--- a/src/services/fieldtranslator/MatrixFieldTranslator.php
+++ b/src/services/fieldtranslator/MatrixFieldTranslator.php
@@ -89,15 +89,13 @@ class MatrixFieldTranslator extends GenericFieldTranslator
         $post = array(
             $fieldHandle => array(),
         );
-
-        $fieldData = array_values($fieldData);
         
         $new = 0;
         foreach ($blocks as $i => $block) {
-            $blockId = $block->id ?? 'new' . ++$new;
+            $blockId = $i = $block->id ?? 'new' . ++$new;
             // $blockData = isset($fieldData[$blockId]) ? $fieldData[$blockId] : array();
             $blockData = isset($fieldData[$i]) ? $fieldData[$i] : array();
-            
+
             $post[$fieldHandle][$blockId] = array(
                 'type'              => $block->getType()->handle,
                 'enabled'           => $block->getAttributes()['enabled'],

--- a/src/services/fieldtranslator/NeoFieldTranslator.php
+++ b/src/services/fieldtranslator/NeoFieldTranslator.php
@@ -71,25 +71,30 @@ class NeoFieldTranslator extends GenericFieldTranslator
         return $source;
     }
 
-    protected function parseBlockData(&$allBlockData, $blockData)
+    protected function parseBlockData(&$allBlockData, $blockData, $blockId=null)
     {
         $newBlockData = array();
         $newToParse = array();
 
         foreach ($blockData as $key => $value) {
             if (is_numeric($key)) {
-                $newToParse[] = $value;
+                $newToParse[$key] = $value;
             } else {
                 $newBlockData[$key] = $value;
             }
         }
 
         if ($newBlockData) {
-            $allBlockData[] = $newBlockData;
+            if($blockId)
+            {
+                $allBlockData[$blockId] = $newBlockData;
+            } else {
+                $allBlockData[] = $newBlockData;
+            }
         }
 
-        foreach ($newToParse as $blockData) {
-            $this->parseBlockData($allBlockData, $blockData);
+        foreach ($newToParse as $blockId => $blockData) {
+            $this->parseBlockData($allBlockData, $blockData, $blockId);
         }
     }
 
@@ -112,7 +117,8 @@ class NeoFieldTranslator extends GenericFieldTranslator
 
         $new = 0;
         foreach ($blocks as $i => $block) {
-            $blockId = $block->id ?? 'new' . ++$new;
+            
+            $blockId = $i = $block->id ?? 'new' . ++$new;
             $blockData = isset($allBlockData[$i]) ? $allBlockData[$i] : array();
 
             $post[$fieldHandle][$blockId] = array(

--- a/src/services/fieldtranslator/NsmFieldsTranslator.php
+++ b/src/services/fieldtranslator/NsmFieldsTranslator.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Translations for Craft plugin for Craft CMS 3.x
+ *
+ * Translations for Craft eliminates error prone and costly copy/paste workflows for launching human translated Craft CMS web content.
+ *
+ * @link      http://www.acclaro.com/
+ * @copyright Copyright (c) 2018 Acclaro
+ */
+
+namespace acclaro\translations\services\fieldtranslator;
+
+use Craft;
+use craft\base\Field;
+use craft\base\Element;
+
+use acclaro\translations\services\App;
+use acclaro\translations\Translations;
+use acclaro\translations\services\ElementTranslator;
+
+use newism\fields\fields\Address;
+use newism\fields\fields\Embed;
+use newism\fields\fields\Gender;
+use newism\fields\fields\PersonName;
+use newism\fields\fields\Telephone;
+use newism\fields\fields\Email;
+
+class NsmFieldsTranslator extends GenericFieldTranslator
+{
+
+    private $addressFields = ['countryCode', 'locality', 'dependentLocality', 'postalCode', 'addressLine1', 'addressLine2', 'organization', 'recipient', 'givenName', 'additionalName', 'familyName'];
+    private $nameFields = ['honorificPrefix', 'givenNames', 'additionalNames', 'familyNames', 'honorificSuffix'];
+
+    private $fieldData;
+
+    private $fieldHandle;
+    /**
+     * {@inheritdoc}
+     */
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+
+        $source = [];
+
+        $fieldHandle = $field->handle;
+        $fieldData = $element->getFieldValue($fieldHandle);
+
+        if ($fieldData) {
+            switch (true) {
+                case get_class($field) == Address::class:
+                    foreach($fieldData as $key => $value)
+                    {
+                        $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                        if (in_array($key, $this->addressFields)) {
+                            $source[$k] = $value;
+                        }
+                    }
+                    break;
+                case get_class($field) == PersonName::class:
+                    foreach($fieldData as $key => $value)
+                    {
+                        if (!empty($value) && in_array($key, $this->nameFields)) {
+                            $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                            $source[$k] = $value;
+                        }
+                    }
+                    break;
+                case get_class($field) == Telephone::class:
+                    foreach($fieldData as $key => $value)
+                    {
+                        if(!empty($fieldData['rawInput']) && in_array($key, ['countryCode', 'rawInput'])) {
+                            $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                            $source[$k] = $value;
+                        }
+                    }
+                    break;
+                case get_class($field) == Gender::class:
+                    foreach($fieldData as $key => $value)
+                    {
+                        if(!empty($fieldData['identity'])) {
+                            $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                            $source[$k] = $value;
+                        }
+                    }
+                    break;
+                case get_class($field) == Embed::class:
+                    foreach($fieldData as $key => $value)
+                    {
+                        if(!empty($fieldData['rawInput']) && $key === 'rawInput') {
+                            $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                            $source[$k] = $value;
+                        }
+                    }
+                    break;
+                case get_class($field) == Email::class:
+                    if(!empty($fieldData)){
+                        $source[$fieldHandle] = $fieldData;
+                    }
+                    break;
+
+                default:
+                    foreach($fieldData as $key => $value)
+                    { 
+                        $k = sprintf('%s.%s.%s', $fieldHandle, $field->id, $key);
+                        $source[$k] = $value;
+                    }
+                    break;
+            }
+        }
+
+        return $source;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toPostArray(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $source = array();
+
+        $fieldHandle = $field->handle;
+
+        $fieldData = $element->getFieldValue($fieldHandle);
+
+        if( $fieldData )
+        {
+            switch (true)
+            {
+                case get_class($field) == Email::class:
+                    $source[$fieldHandle] = $fieldData;
+                    break;
+                
+                default:
+                    foreach($fieldData as $key => $value)
+                    {
+                        $source[$fieldHandle][$key] = $value;
+                    }
+                    break;
+            }
+        }
+
+        return $source;
+    }
+
+    /**
+     * {@inheritdoc} 
+     */
+    public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite, $targetSite, $fieldData)
+    {
+
+        $fieldHandle = $field->handle;
+        
+        $post = array();
+        
+        $postRow = array();
+
+        $post = $this->toPostArray($elementTranslator, $element, $field);
+
+        if( $fieldData && $post)
+        {
+            switch (true)
+            {
+                case get_class($field) == Email::class:
+                    $post[$fieldHandle] = $fieldData;
+                    break;
+                
+                default:
+                    foreach ($fieldData as $i => $row)
+                    {
+                        if ( $field->id == $i)
+                        {
+                            foreach ($post[$fieldHandle] as $key => $value)
+                            { 
+                                if (isset($row[$key]))
+                                {
+                                    $post[$fieldHandle][$key] = $row[$key];
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return $post;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWordCount(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+
+        $data = $this->getFieldValue($elementTranslator, $element, $field);
+
+        if (!$data) {
+            return 0;
+        }
+
+        $wordCount = 0;
+
+        if (!is_array($data)) {
+            switch (true) {
+                case get_class($field) == Gender::class:
+                    break;
+                
+                default:
+                    $wordCount = Translations::$plugin->wordCounter->getWordCount(strip_tags($data));
+                    break;
+            }
+            
+            return $wordCount;
+        }
+
+        foreach ($data as $key => $value) 
+        {
+            if($key === 'customText' || $key === 'ariaLabel' || $key === 'title')
+            {
+                $wordCount += Translations::$plugin->wordCounter->getWordCount(strip_tags($value));
+            }
+        }
+        return $wordCount;
+    }
+}

--- a/src/services/fieldtranslator/SeoFieldTranslator.php
+++ b/src/services/fieldtranslator/SeoFieldTranslator.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Translations for Craft plugin for Craft CMS 3.x
+ *
+ * Translations for Craft eliminates error prone and costly copy/paste workflows for launching human translated Craft CMS web content.
+ *
+ * @link      http://www.acclaro.com/
+ * @copyright Copyright (c) 2018 Acclaro
+ */
+
+namespace acclaro\translations\services\fieldtranslator;
+
+use Craft;
+use craft\base\Field;
+use craft\base\Element;
+use craft\elements\Tag;
+use craft\helpers\Json;
+use acclaro\translations\services\App;
+use acclaro\translations\Translations;
+use acclaro\translations\services\ElementTranslator;
+
+class SeoFieldTranslator extends GenericFieldTranslator
+{
+    private $translatableAttributes = ['titleRaw', 'descriptionRaw', 'keywords', 'social'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $source = array();
+
+        $meta = $element->getFieldValue($field->handle);
+
+        if ($meta) {
+            foreach ($this->translatableAttributes as $attribute) {
+
+                if (is_array($meta->$attribute)) {
+                    
+                    foreach ($meta->$attribute as $key => $val){
+                        if($attribute == 'social')
+                        {
+                            $new_key = sprintf('%s.%s.%s.%s', $field->handle, $attribute, $key, 'title');
+                            $source[$new_key] = $val->title;
+
+                            $new_key = sprintf('%s.%s.%s.%s', $field->handle, $attribute, $key, 'description');
+                            $source[$new_key] = $val->description;
+                        } else if($attribute == 'keywords') {
+                            $new_key = sprintf('%s.%s.%s.%s', $field->handle, $attribute, $key,'keyword');
+                            $source[$new_key] = $val['keyword'];
+                        } else {
+                            $key = sprintf('%s.%s.%s', $field->handle, $attribute, $key);
+                            $source[$key] = $val;
+                        }
+                    }
+
+                } else {
+                    if ($meta->$attribute) {
+                        $key = sprintf('%s.%s', $field->handle, $attribute);
+
+                        $source[$key] = $meta->$attribute;
+                    }
+                }
+            }
+        }
+
+        return $source;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toPostArray(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $fieldHandle = $field->handle;
+
+        $meta = $element->getFieldValue($fieldHandle);
+
+        $source = array();
+
+        if( $meta )
+        {
+            foreach($meta as $key => $value)
+            {
+                $source[$fieldHandle][$key] = $value;
+            }
+        }
+
+        return $source;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceLanguage, $targetLanguage, $fieldData)
+    {
+        $fieldHandle = $field->handle;
+
+        $post = $this->toPostArray($elementTranslator, $element, $field);
+
+        foreach ($this->translatableAttributes as $attribute) {
+            if (isset($fieldData[$attribute])) {
+                $post[$fieldHandle][$attribute] = $fieldData[$attribute];
+            }
+        }
+
+        return $post;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWordCount(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $wordCount = 0;
+
+        $meta = $element->getFieldValue($field->handle);
+
+        if ($meta) {
+            foreach ($this->translatableAttributes as $attribute) {
+                $value = $meta->$attribute;
+
+                if (is_array($value)) {
+                    foreach ($value as $key => $val){
+                        if($attribute == 'social')
+                        {
+                            $wordCount += Translations::$plugin->wordCounter->getWordCount($val->title);
+                            $wordCount += Translations::$plugin->wordCounter->getWordCount($val->description);
+                        } else {
+                            $val = is_array($val) ? $val['keyword'] : $val;
+                            $wordCount += Translations::$plugin->wordCounter->getWordCount($val);
+                        }
+                    }
+                } else {
+                    $wordCount += Translations::$plugin->wordCounter->getWordCount($value);
+                }
+
+            }
+        }
+
+        return $wordCount;
+    }
+}

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -69,10 +69,10 @@ class DraftRepository
     
     public function publishDraft(Entry $draft)
     {
-        // Let's save the draft before we pass it to applyDraft()
+        // Let's save the draft before we pass it to publishDraft()
         Craft::$app->elements->saveElement($draft);
 
-        return Craft::$app->getDrafts()->applyDraft($draft);
+        return Craft::$app->getDrafts()->publishDraft($draft);
     }
 
     public function deleteAutoPropagatedDrafts($draftId, $targetSite)
@@ -145,7 +145,7 @@ class DraftRepository
     public function applyTranslationDraft($fileId)
     {
         $file = Translations::$plugin->fileRepository->getFileById($fileId);
-
+        
         // Get file's draft
         $draft = Translations::$plugin->draftRepository->getDraftById($file->draftId, $file->targetSite);
 
@@ -163,7 +163,7 @@ class DraftRepository
             Translations::$plugin->draftRepository->deleteAutoPropagatedDrafts($file->draftId, $file->targetSite);
 
             // Apply the draft to the entry
-            $newEntry = Craft::$app->getDrafts()->applyDraft($draft);
+            $newEntry = Craft::$app->getDrafts()->publishDraft($draft);
 
 
         } catch (InvalidElementException $e) {
@@ -187,12 +187,12 @@ class DraftRepository
         $totalElements = (count($elements) * count($order->getTargetSitesArray()));
         $currentElement = 0;
 
-        $creatDrafts = new CreateDrafts();
+        $createDrafts = new CreateDrafts();
         foreach ($order->getTargetSitesArray() as $key => $site) {
             foreach ($elements as $element) {
 
                 if ($queue) {
-                    $creatDrafts->updateProgress($queue, $currentElement++/$totalElements);
+                    $createDrafts->updateProgress($queue, $currentElement++/$totalElements);
                 }
 
                 $this->createDrafts($element, $order, $site, $wordCounts);
@@ -308,19 +308,21 @@ class DraftRepository
                 ->admin()
                 ->orderBy(['elements.id' => SORT_ASC])
                 ->one();
+            
             $creatorId = $creator->id;
-
             $name = sprintf('%s [%s]', $orderName, Craft::$app->getSites()->getSiteById($site)->handle);
-
             $notes = '';
+            $elementURI = Craft::$app->getElements()->getElementUriForSite($entry->id, $site);
             //$supportedSites = Translations::$plugin->entryRepository->getSupportedSites($entry);
+
             $newAttributes = [
                 // 'enabledForSite' => in_array($site, $supportedSites),
                 'siteId' => $site,
+                'uri' => $elementURI,
             ];
 
             $draft = Translations::$plugin->draftRepository->makeNewDraft($entry, $creatorId, $name, $notes, $newAttributes);
-
+            
             return $draft;
         } catch (Exception $e) {
 

--- a/src/services/repository/StaticTranslationsRepository.php
+++ b/src/services/repository/StaticTranslationsRepository.php
@@ -83,48 +83,50 @@ class StaticTranslationsRepository
         foreach ($fileOptions['regex'] as $regex) {
             if (preg_match_all($regex, $contents, $matches)) {
                 $position = $fileOptions['position'];
-                foreach ($matches[$position] as $original) {
-                    $translateId = ElementHelper::createSlug($original);
-                    $view = Craft::$app->getView();
-                    $site = Craft::$app->getSites()->getSiteById($query->siteId);
-                    $translation = Craft::t($category, $original, null, $site->language);
+                if(isset($matches[$position])){
+                    foreach ($matches[$position] as $original) {
+                        $translateId = ElementHelper::normalizeSlug($original);
+                        $view = Craft::$app->getView();
+                        $site = Craft::$app->getSites()->getSiteById($query->siteId);
+                        $translation = Craft::t($category, $original, null, $site->language);
 
-                    $field = $view->renderTemplate('_includes/forms/text', [
-                        'id' => $translateId,
-                        'name' => 'translation['.$original.']',
-                        'value' => $translation,
-                        'placeholder' => $translation,
-                    ]);
+                        $field = $view->renderTemplate('_includes/forms/text', [
+                            'id' => $translateId,
+                            'name' => 'translation['.$original.']',
+                            'value' => $translation,
+                            'placeholder' => $translation,
+                        ]);
 
-                    $element = new StaticTranslations([
-                        'id' => $elementId,
-                        'translateId' => ElementHelper::createSlug($original),
-                        'original' => $original,
-                        'translation' => $translation,
-                        'source' => $path,
-                        'file' => $file,
-                        'siteId' => $query->siteId,
-                        'field' => $field,
-                    ]);
+                        $element = new StaticTranslations([
+                            'id' => $elementId,
+                            'translateId' => ElementHelper::normalizeSlug($original),
+                            'original' => $original,
+                            'translation' => $translation,
+                            'source' => $path,
+                            'file' => $file,
+                            'siteId' => $query->siteId,
+                            'field' => $field,
+                        ]);
 
-                    $elementId++;
-                    if ($query->status && $query->status != $element->getTranslateStatus()) {
-                        continue;
-                    }
-                    if ($query->search && !stristr($element->original, $query->search) && !stristr($element->translation, $query->search)) {
-                        continue;
-                    }
+                        $elementId++;
+                        if ($query->status && $query->status != $element->getTranslateStatus()) {
+                            continue;
+                        }
+                        if ($query->search && !stristr($element->original, $query->search) && !stristr($element->translation, $query->search)) {
+                            continue;
+                        }
 
-                    if ($query->id)
-                    {
-                        foreach ($query->id as $id) {
-                            if ($element->id == $id) {
-                                $translations[$element->original] = $element;
+                        if ($query->id)
+                        {
+                            foreach ($query->id as $id) {
+                                if ($element->id == $id) {
+                                    $translations[$element->original] = $element;
+                                }
                             }
                         }
-                    }
-                    else{
-                        $translations[$element->original] = $element;
+                        else{
+                            $translations[$element->original] = $element;
+                        }
                     }
                 }
             }

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -90,7 +90,11 @@ class AcclaroTranslationService implements TranslationServiceInterface
                 sprintf(Translations::$plugin->translator->translate('app', 'Order status changed to %s'), $orderResponse->status)
             );
         }
-
+        
+        if ($order->title !== $orderResponse->name) {
+            Translations::$plugin->orderRepository->saveOrderName($order->id, $orderResponse->name);
+        }
+        
         $order->status = $orderResponse->status;
     }
 
@@ -294,7 +298,7 @@ class AcclaroTranslationService implements TranslationServiceInterface
             $targetSite = Translations::$plugin->siteRepository->normalizeLanguage(Craft::$app->getSites()->getSiteById($file->targetSite)->language);
 
             if ($element instanceof GlobalSetModel) {
-                $filename = ElementHelper::createSlug($element->name).'-'.$targetSite.'.xml';
+                $filename = ElementHelper::normalizeSlug($element->name).'-'.$targetSite.'.xml';
             } else {
                 $filename = $element->slug.'-'.$targetSite.'.xml';
             }

--- a/src/services/translator/Export_ImportTranslationService.php
+++ b/src/services/translator/Export_ImportTranslationService.php
@@ -115,9 +115,9 @@ class Export_ImportTranslationService implements TranslationServiceInterface
             case $draft instanceof Entry:
                 $draft->title = isset($targetData['title']) ? $targetData['title'] : $draft->title;
                 $draft->slug = isset($targetData['slug']) ? $targetData['slug'] : $draft->slug;
-                
+
                 $post = Translations::$plugin->elementTranslator->toPostArrayFromTranslationTarget($draft, $sourceSite, $targetSite, $targetData);
-                
+
                 $draft->setFieldValues($post);
                 
                 $draft->siteId = $targetSite;

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -33,6 +33,19 @@
 {% block content %}
     {% if isSubmitted %}
 
+        <div class="top-order-navigation">
+            {% if previous_order %}
+                <a href="{{ previous_order }}"> « Previous Order </a>
+            {% else %}
+                « Previous Order
+            {% endif %}
+            {% if next_order %}
+                <a href="{{ next_order }}"> Next Order »</a>
+            {% else %}
+                Next Order »
+            {% endif %}
+        </div>
+
         <div style="display: flex">
             <div class="translations-order-detail-summary">
 
@@ -132,9 +145,7 @@
                     <tr>
                         <th>{{ 'Name'|t }}</th>
                         <td> <span class="order_label"> <span id="order_name"> {{ order.title }} </span> &nbsp;
-                                {% if order.translator.service is defined and order.translator.service == 'export_import' %}
                                     <a class="icon edit editOrder" title="Edit Order Name"></a>
-                                {% endif %}
                             </span>
                             <span id="order_name_input" style="display: none">
                                 <input type="hidden" id="order_id" value="{{ order.id }}">
@@ -505,6 +516,19 @@
                     </div>
                 </div>
             </div>
+        </div>
+
+        <div class="footer-order-navigation">
+            {% if previous_order %}
+                <a href="{{ previous_order }}"> « Previous Order </a>
+            {% else %}
+                « Previous Order
+            {% endif %}
+            {% if next_order %}
+                <a href="{{ next_order }}"> Next Order »</a>
+            {% else %}
+                Next Order »
+            {% endif %}
         </div>
 
     {% elseif orderSubmitted %}


### PR DESCRIPTION
## Added
- NSM Email field support [`newism\fields\fields\Email`](https://github.com/newism/craft3-fields/blob/master/src/fields/Email.php) (#139)
- NSM Telephone field support [`newism\fields\fields\Telephone`](https://github.com/newism/craft3-fields/blob/master/src/fields/Telephone.php) (#139)
- NSM Address field support [`newism\fields\fields\Address`](https://github.com/newism/craft3-fields/blob/master/src/fields/Address.php) (#139)
- NSM Embed field support [`newism\fields\fields\Embed`](https://github.com/newism/craft3-fields/blob/master/src/fields/Embed.php) (#139)
- Ether, SEO field support [`ether\seo\fields\SeoField`](https://github.com/ethercreative/seo/blob/v3/src/fields/SeoField.php#L24) (#136)
- Bi-direction Sync for Acclaro Order name updates (#134)
- Support for [Craft 3.6](https://github.com/craftcms/cms/blob/3.6.0/CHANGELOG.md#360---2021-01-26) (#144)
- Improved Order navigation (#149)

## Fixed
- Non-localized field interference within localized 'nested' blocks (#140)
- Source lang is included as target lang when selecting 'All' target languages   (#134)
- Adding Entries to a 'Saved' Order triggers new Order (#137)
- Prevent translation drafts from getting published via Craft (fd0bc80)
- Translation Draft URI structures (#145)