### PR TITLE
Release/1.10.3

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Easily launch and manage multilingual Craft websites without having to copy/paste content or manually track updates.",
-    "pluginVersion": "1.10.2",
+    "pluginVersion": "1.10.3",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.10.3 - 2021-04-06
+
+### Updated
+- Use `UrlHelper::baseSiteUrl()` instead of deprecated `App::env('SITE_URL')` for generating Order URLs
+
+### Fixed
+- Issue when applying drafts via Queue Manager
+
 ## 1.10.2 - 2021-03-11
 
 ### Fixed

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -529,6 +529,7 @@ class Translations extends Plugin
         $applyDraftActions = [
             'apply-drafts',
             'apply-translation-draft',
+            'run',
         ];
 
         if(!empty($response) && !in_array($action, $applyDraftActions)) {

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -276,7 +276,7 @@ class OrderRepository
 
         $totalElements = count($order->files);
         $currentElement = 0;
-        $orderUrl = App::env('SITE_URL') .'admin/translations/orders/detail/'.$order->id;
+        $orderUrl = UrlHelper::baseSiteUrl() .'admin/translations/orders/detail/'.$order->id;
         $orderUrl = "Craft Order: <a href='$orderUrl'>$orderUrl</a>";
         $comments = $order->comments ? $order->comments .' | '.$orderUrl : $orderUrl;
 


### PR DESCRIPTION
### Updated
- Use `UrlHelper::baseSiteUrl()` instead of deprecated `App::env('SITE_URL')` for generating Order URLs

### Fixed
- Issue when applying drafts via Queue Manager