### PR TITLE
Updated deprecated sourceId method with getCanonicalId

### DIFF
--- a/src/services/UrlGenerator.php
+++ b/src/services/UrlGenerator.php
@@ -122,7 +122,7 @@ class UrlGenerator
             $route = [
                 'preview/preview', [
                     'elementType' => $className,
-                    'sourceId' => $element->sourceId,
+                    'sourceId' => $element->getCanonicalId(),
                     'siteId' => $siteId ? $siteId : $element->siteId,
                     'draftId' => $element->draftId,
                     'revisionId' => $element->revisionId

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -314,15 +314,15 @@ class DraftRepository
 
         try {
             // Prevent duplicate files
-            $isExistingFile = $this->isTranslationDraft($draft->draftId, $draft->sourceId);
+            $isExistingFile = $this->isTranslationDraft($draft->draftId, $draft->getCanonicalId());
             if (!empty($isExistingFile)) {
                 return;
             }
 
-            $element = Craft::$app->getElements()->getElementById($draft->sourceId, null, $order->sourceSite);
+            $element = Craft::$app->getElements()->getElementById($draft->getCanonicalId(), null, $order->sourceSite);
 
             $file->orderId = $order->id;
-            $file->elementId = $draft->sourceId;
+            $file->elementId = $draft->getCanonicalId();
             $file->draftId = $draft->draftId;
             $file->sourceSite = $order->sourceSite;
             $file->targetSite = $targetSite;
@@ -345,7 +345,7 @@ class DraftRepository
         } catch (Exception $e) {
             
             $file->orderId = $order->id;
-            $file->elementId = $draft->sourceId;
+            $file->elementId = $draft->getCanonicalId();
             $file->draftId = $draft->draftId;
             $file->sourceSite = $order->sourceSite;
             $file->targetSite = $targetSite;


### PR DESCRIPTION
## Updated

- Deprecated `sourceId` method with `getCanonicalId()`