### PR TITLE
change News widget to use Craft's guzzle client settings

### DIFF
--- a/src/widgets/News.php
+++ b/src/widgets/News.php
@@ -114,7 +114,7 @@ class News extends Widget
     {
         $articles = [];
         
-        $client = new Client(array(
+        $client = Craft::createGuzzleClient(array(
             'base_uri' => 'https://www.acclaro.com/',
             'timeout' => 2.0,
             'verify' => false


### PR DESCRIPTION
We're trying to use this plugin on a secured site that requires all outgoing connections go through a proxy. Even with the proxy configured within Craft, we were still unable to view /admin/translations because the News widget is configured to use Guzzle directly and bypasses Craft's settings.

This one line change updates the news widget to use `Craft::createGuzzleClient` instead of `new Client`. This same update may also be required on line 29 of AcclaroApiClient.php, but since we're not using the Acclaro API yet I can't say for certain or test that change.