### PR TITLE
New order testing issues fixes

### DIFF
--- a/src/assetbundles/src/js/OrderDetails.js
+++ b/src/assetbundles/src/js/OrderDetails.js
@@ -306,7 +306,7 @@
         var updatedVersions = [];
         $.each(elementVersions, function(key, value) {
             elementId = value.split('_')[0];
-            if ($.inArray(elementId, currentElementIds)) {
+            if ($.inArray(elementId, currentElementIds) > -1) {
                 updatedVersions.push(value);
             }
         });

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -235,8 +235,10 @@ class OrderController extends Controller
         $variables['elements'] = [];
         $variables['elementVersionMap'] = array();
         $originalElementIds = [];
+        $finalElements = [];
 
         foreach ($variables['order']->getElements() as $element) {
+            $finalElements[$element->id] = $element;
             if ($element->getIsDraft()) {
                 $variables['elementVersionMap'][$element->getCanonicalId()] = $element->draftId;
                 array_push($originalElementIds, $element->getCanonicalId());
@@ -253,6 +255,7 @@ class OrderController extends Controller
 
                 if ($element) {
                     $variables['elements'][] = $element;
+                    if (! in_array($element->id, $finalElements)) $finalElements[$element->id] = $element;
                     if (! isset($variables['elementVersionMap'][$element->id])) {
                         $variables['elementVersionMap'][$element->id] = 'current';
                     }
@@ -293,7 +296,7 @@ class OrderController extends Controller
         $variables['entriesCountByElementCompleted'] = 0;
         $variables['translatedFiles'] = [];
 
-        foreach ($variables['order']->getElements() as $element) {
+        foreach ($finalElements as $key => $element) {
             $drafts = Craft::$app->getDrafts()->getEditableDrafts($element);
             $tempElement = $element;
             $element = $element->getIsDraft() ? $element->getCanonical(true) : $element;
@@ -329,17 +332,18 @@ class OrderController extends Controller
                 $isElementPublished = true;
 
                 foreach ($variables['files'][$element->id] as $file) {
-                    $translatedElement = Craft::$app->getElements()->getElementById($file->elementId, null, $file->targetSite);
-
+                    $translatedElement = Craft::$app->getElements()->getElementById($element->id, null, $file->targetSite);
                     if ($file->status !== Constants::FILE_STATUS_PUBLISHED) {
                         $isElementPublished = false;
                     }
-                    if ($file->status === Constants::FILE_STATUS_COMPLETE) {
-                        $draft = Translations::$plugin->draftRepository->getDraftById($file->draftId, $file->targetSite);
-                        $variables['translatedFiles'][$file->id] = $element->title;
-                    } else if ($file->status === Constants::FILE_STATUS_PUBLISHED) {
 
-                        $variables['translatedFiles'][$file->id] = $translatedElement->title ?? $element->title;
+                    if ($file->status === Constants::FILE_STATUS_COMPLETE) {
+                        $draftElement = Translations::$plugin->draftRepository->getDraftById($file->draftId, $file->targetSite);
+                        $variables['translatedFiles'][$file->id] = $draftElement->title;
+                    } else if ($file->status === Constants::FILE_STATUS_PUBLISHED) {
+                        $variables['translatedFiles'][$file->id] = $translatedElement->title;
+                    } else {
+                        $variables['translatedFiles'][$file->id] = $tempElement->title;
                     }
 
                     if ($element instanceof Entry) {
@@ -473,10 +477,14 @@ class OrderController extends Controller
             if ($variables['order']->status == Constants::ORDER_STATUS_CANCELED) {
                 $variables['isEditable'] = false;
             }
-            if (
-                $orderStatus === Constants::ORDER_STATUS_COMPLETE ||
-                $variables['order']->status == Constants::ORDER_STATUS_CANCELED
-            ) $variables['isEditable'] = false;
+            if ($orderStatus === Constants::ORDER_STATUS_COMPLETE) {
+                $variables['isEditable'] = false;
+                if ($variables['order']->status === Constants::ORDER_STATUS_PUBLISHED) {
+                    $variables['orderRecentStatus'] = Constants::ORDER_STATUS_PUBLISHED;
+                } else {
+                    $variables['orderRecentStatus'] = $orderStatus;
+                }
+            }
         }
 
         $variables['isSubmitted'] = ($variables['order']->status !== Constants::ORDER_STATUS_NEW &&

--- a/src/services/ElementToFileConverter.php
+++ b/src/services/ElementToFileConverter.php
@@ -372,7 +372,7 @@ class ElementToFileConverter
         foreach ($body as $node) {
             foreach ($node->getElementsByTagName('content') as $child) {
                 $key    = $child->getAttribute('resname');
-                $value  = $child->childNodes[0]->nodeValue;
+                $value  = $child->childNodes[0] ? $child->childNodes[0]->nodeValue : '';
 
                 $headers .= ",\"$key\"";
                 $content .= ",\"$value\"";

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -342,7 +342,7 @@ class AcclaroTranslationService implements TranslationServiceInterface
             } else if ($element instanceof Asset) {
                 $assetFilename = $element->getFilename();
                 $fileInfo = pathinfo($element->getFilename());
-                $filename = $file->elementId . '-' . basename($assetFilename,'.'.$fileInfo['extension']) . '-' . $targetSite . '.' . $fileFormat;
+                $filename = $file->elementId . '-' . basename($assetFilename,'.'.$fileInfo['extension']) . '-' . $targetSite . '.' . Constants::FILE_FORMAT_XML;
             } else {
                 $filename = $element->slug.'-'.$targetSite.'.'.Constants::FILE_FORMAT_XML;
             }


### PR DESCRIPTION
Following are the issues found in QA and fixed:
1. File download in json/csv format failing for asset elements.
2. Acclaro order's recent status not syncing on order detail page load.
3. Entries removed from source entries were added to the order after creating an order.
4. Draft title was not loading correctly.
5. Asset acclaro order issue with file format undefined variable.