### PR TITLE
Hotfix/translator authentication

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -349,7 +349,7 @@ class BaseController extends Controller
         $translator = $order->getTranslator();
         $service = $translator->service;
         $settings = $translator->getSettings();
-        $authenticate = AcclaroService::authenticateService($service, $settings);
+        $authenticate = (new AcclaroService())->authenticateService($service, $settings);
         
         if (!$authenticate && $service === Constants::TRANSLATOR_ACCLARO) {
             $message = Translations::$plugin->translator->translate('app', 'Invalid API key');


### PR DESCRIPTION
### Fixed

- `authenticateService()` is not a static method and can't be called statically