### PR TITLE
hotfix/nested-block-canonical-ids

### DIFF
--- a/src/services/fieldtranslator/MatrixFieldTranslator.php
+++ b/src/services/fieldtranslator/MatrixFieldTranslator.php
@@ -32,7 +32,7 @@ class MatrixFieldTranslator extends GenericFieldTranslator
             
             $new = 0;
             foreach ($blocks as $block) {
-                $blockId = $block->fieldId . "_" . $block->typeId ?? 'new' . ++$new;
+                $blockId = $block->fieldId . "_" . $block->canonicalId ?? 'new' . ++$new;
                 $blockSource = $elementTranslator->toTranslationSource($block);
 
                 foreach ($blockSource as $key => $value) {
@@ -93,7 +93,7 @@ class MatrixFieldTranslator extends GenericFieldTranslator
         $new = 0;
         foreach ($blocks as $i => $block) {
             $blockId = $block->id ?? 'new' . ++$new;
-            $i = $block->fieldId . "_" . $block->typeId ?? 'new' . ++$new;
+            $i = $block->fieldId . "_" . $block->canonicalId ?? 'new' . ++$new;
             // $blockData = isset($fieldData[$blockId]) ? $fieldData[$blockId] : array();
             $blockData = isset($fieldData[$i]) ? $fieldData[$i] : array();
 

--- a/src/services/fieldtranslator/NeoFieldTranslator.php
+++ b/src/services/fieldtranslator/NeoFieldTranslator.php
@@ -33,7 +33,7 @@ class NeoFieldTranslator extends GenericFieldTranslator
             // foreach ($blocks->level(1) as $block) { // removed in 3.2
             $new = 0;
             foreach ($blocks as $block) {
-                $blockId = $block->fieldId . "_" . $block->typeId ?? 'new' . ++$new;
+                $blockId = $block->fieldId . "_" . $block->canonicalId ?? 'new' . ++$new;
                 $keyPrefix = sprintf('%s.%s', $field->handle, $blockId);
 
                 $source = array_merge($source, $this->blockToTranslationSource($elementTranslator, $block, $keyPrefix));
@@ -117,7 +117,7 @@ class NeoFieldTranslator extends GenericFieldTranslator
         $new = 0;
         foreach ($blocks as $i => $block) {
             $blockId = $block->id ?? 'new' . ++$new;
-            $i = $block->fieldId . "_" . $block->typeId ?? 'new' . ++$new;
+            $i = $block->fieldId . "_" . $block->canonicalId ?? 'new' . ++$new;
             $blockData = isset($allBlockData[$i]) ? $allBlockData[$i] : array();
 
             $post[$fieldHandle][$blockId] = array(


### PR DESCRIPTION
### Fixed

- Use the block's `canonicalId` instead of `typeId` (#237)