### PR TITLE
fix: duplicate modified status on order index page

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -212,16 +212,6 @@ class Order extends Element
                 'defaultSort' => ['dateOrdered', 'desc']
             ],
             [
-                'key' => 'modified',
-                'label' => Translations::$plugin->translator->translate('app', 'Modified'),
-                'criteria' => [
-                    'status' => [
-                        Constants::ORDER_STATUS_MODIFIED
-                    ]
-                ],
-                'defaultSort' => ['dateOrdered', 'desc']
-            ],
-            [
                 'key' => 'in-progress',
                 'label' => Translations::$plugin->translator->translate('app', 'In progress'),
                 'criteria' => [


### PR DESCRIPTION
- [ ] Removed duplicate "modified" status on order index page

![image](https://user-images.githubusercontent.com/32937137/151050002-235d6893-5175-429b-937f-abc7e464052b.png)
