### PR TITLE
fix:guzzle version dependabot alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.7.33",
-        "guzzlehttp/guzzle": "^6.3|^7.0",
+        "guzzlehttp/guzzle": "^6.5.7|^7.0",
         "php": ">=7.2.0",
         "sebastian/diff": "^3.0",
         "composer/composer": "^2.1.9",


### PR DESCRIPTION
- Updated min requirement for `guzzlehttp/guzzle` from 6.3 to 6.5.7