### PR TITLE
fix: error when updating source content when no draft exists

### DIFF
--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -1433,8 +1433,10 @@ class OrderController extends Controller
 
                     // Delete draft here so that it does not try to merge in existing draft when merged after updating
                     // source entry in order
-                    Translations::$plugin->draftRepository->deleteDraft($file->draftId, $file->targetSite);
-                    $file->draftId = null;
+                    if ($file->hasDraft()) {
+                        Translations::$plugin->draftRepository->deleteDraft($file->draftId, $file->targetSite);
+                        $file->draftId = null;
+                    }
                     $file->status = Constants::FILE_STATUS_MODIFIED;
                     Translations::$plugin->fileRepository->saveFile($file);
 

--- a/src/elements/actions/OrderDelete.php
+++ b/src/elements/actions/OrderDelete.php
@@ -83,6 +83,9 @@ class OrderDelete extends Delete
                     if ($file->hasDraft()) {
                         $element = $file->getElement();
 
+                        // Skip if the entry has been deleted
+                        if (! $element) continue;
+
                         switch (get_class($element)) {
                             case ($element instanceof GlobalSet):
                                 $elementRepository = Translations::$plugin->globalSetDraftRepository;


### PR DESCRIPTION
- [ ] Fixed an error occurred when updating source content (Deleting existing draft) when file does not have a draft created.
- [ ] Fixed error permanent deleting orders from index page when source entry already deleted.