### PR TITLE
fix: missing api param in sycn order

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -82,7 +82,8 @@ class Constants
     const DELIVERY      = 'craftcms';
     const DEFAULT_TAG   = 'CraftCMS';
 
-    const ORDER_TAG_GROUP_HANDLE = "craftTranslations";
+    const ORDER_TAG_GROUP_HANDLE    = "craftTranslations";
+    const ACCLARO_TARGET_FILE_TYPE  = 'target';
 
     // Acclaro Order Comments
     const ACCLARO_FILE_NEW      = 'NEW FILE';

--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -200,7 +200,7 @@ class FileModel extends Model
 	public function hasSourceTargetDiff()
 	{
 		$hasDiff = false;
-		if ($this->isReviewReady() || $this->isComplete() || $this->isPublished()) {
+		if (!empty($this->target) && ($this->isReviewReady() || $this->isComplete() || $this->isPublished())) {
 			$hasDiff = (bool) Translations::$plugin->fileRepository->getSourceTargetDifferences(
 				$this->source, $this->target);
 		}

--- a/src/services/api/AcclaroApiClient.php
+++ b/src/services/api/AcclaroApiClient.php
@@ -426,7 +426,8 @@ class AcclaroApiClient
     public function getFileInfo($orderId)
     {
         return $this->get(Constants::ACCLARO_API_GET_ORDER_FILES_INFO, array(
-            'orderid' => $orderId,
+            'orderid'   => $orderId,
+            'filetype'  => Constants::ACCLARO_TARGET_FILE_TYPE,
         ));
     }
 


### PR DESCRIPTION
- [ ] Added a get order api request param missing.
- [ ] Added a check for target content before checking for sourceTarget changes (#341)