### PR TITLE
fix: translation rows removed on delete site

### DIFF
--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -146,6 +146,9 @@ class OrderController extends Controller
             $variables['inputElements'] = $orderElements ?: [];
         }
 
+        // Check if source site is exists
+        if (!Craft::$app->getSites()->getSiteById($order->sourceSite)) throw new Exception("Source Site Does Not Exist", 404);
+
 		// Check for changes if we are adding an element
 		if ($variables['isChanged']) {
 			if ($orderTitle= Craft::$app->getRequest()->getQueryParam('title')) {

--- a/src/services/UrlGenerator.php
+++ b/src/services/UrlGenerator.php
@@ -55,13 +55,17 @@ class UrlGenerator
 
     public function generateFileUrl(Element $element, FileModel $file)
     {
+        /** @var \craft\services\Sites $sitesService */
+        $sitesService = Craft::$app->getSites();
+        $targetSite = $sitesService->getSiteById($file->targetSite) ?? $sitesService->getSiteById($file->sourceSite) ?? $sitesService->getPrimarySite();
+
         if ($element instanceof GlobalSet) {
             if ($file->draftId && $file->isComplete()) {
                 return Translations::$plugin->urlHelper->cpUrl('translations/globals/'.$element->handle.'/drafts/'.$file->draftId);
             }
             return preg_replace(
                 '/(\/'.Craft::$app->sites->getSiteById($element->siteId)->handle.')/',
-                '/'.Craft::$app->sites->getSiteById($file->targetSite)->handle,
+                '/'.$targetSite->handle,
                 $element->getCpEditUrl($element)
             );
         }
@@ -74,7 +78,7 @@ class UrlGenerator
             }
             return Translations::$plugin->urlHelper->url(
                 $element->getCpEditUrl($element),
-                ['site' => Craft::$app->sites->getSiteById($file->targetSite)->handle]
+                ['site' => $targetSite->handle]
             );
         }
 
@@ -83,12 +87,12 @@ class UrlGenerator
                 return Translations::$plugin->urlHelper->cpUrl('translations/assets/'.$element->id.'/drafts/'.$file->draftId);
             }
             return Translations::$plugin->urlHelper->url($element->getCpEditUrl(),
-                ['site' => Craft::$app->sites->getSiteById($file->targetSite)->handle]
+                ['site' => $targetSite->handle]
             );
         }
 
         $data = [
-            'site' => Craft::$app->sites->getSiteById($file->targetSite)->handle,
+            'site' => $targetSite->handle,
         ];
 
         if ($file->draftId && $file->isComplete()) {

--- a/src/templates/_components/orders/files-tab.twig
+++ b/src/templates/_components/orders/files-tab.twig
@@ -84,13 +84,15 @@
 							<td>
 								<table>
 									<tr>
-										<td>
-											{% if siteObjects[file.targetSite] is defined %}
+										{% if siteObjects[file.targetSite] is defined %}
+											<td>
 												{{siteObjects[file.targetSite].name}} ({{ siteObjects[file.targetSite].language }})
-											{% else %}
+											</td>
+										{% else %}
+											<td style="color:red;">
 												{{ "Deleted" }}
-											{% endif %}
-										</td>
+											</td>
+										{% endif %}
 									</tr>
 								</table>
 							</td>


### PR DESCRIPTION
## Fixed
- [ ] Error loading order details when source/target site is deleted.

## Updated
- [ ] Logic to remove rows of site from `translation_translations` table when a site is deleted.
- [ ] When a target site is deleted the text `deleted` is shown red in files info tab.