### PR TITLE
fix: showing tm alert after source update

### DIFF
--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -348,7 +348,7 @@ class OrderController extends Controller
             $variables['isSourceChanged'] = Translations::$plugin->orderRepository->getIsSourceChanged($order);
 		}
 
-		if ($order->trackTargetChanges && $variables['isSubmitted'] && $order->hasTmMisalignments()) {
+		if ($order->trackTargetChanges && $variables['isSubmitted'] && $order->isTmMisaligned()) {
             $variables['isTargetChanged'] = Translations::$plugin->orderRepository->getIsTargetChanged($order);
 		}
 

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -430,7 +430,7 @@ class Order extends Element
 
     public function getTargetAlertHtml() {
         $html = '';
-        if (!$this->isPublished() && $this->hasTmMisalignments() && $this->trackTargetChanges) {
+        if (!$this->isPublished() && $this->isTmMisaligned() && $this->trackTargetChanges) {
             $html .= '<span class="nowrap pl-5"><span class="warning order-warning font-size-15" data-icon="alert"> This order contains misaligned content that might affect translation memory accuracy. </span></span>';
         }
 
@@ -626,7 +626,7 @@ class Order extends Element
         return $this->statusLabel;
     }
 
-    public function hasTmMisalignments($ignoreNew = true)
+    public function isTmMisaligned($ignoreNew = true)
     {
         foreach ($this->getFiles() as $file) {
             if ($file->isPublished() || ($ignoreNew && $file->isNew())) continue;

--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -225,11 +225,13 @@ class FileModel extends Model
 
     public function hasTmMisalignments($ignoreReference = false)
     {
-        if ($this->reference !== null) {
-            return $ignoreReference ?: $this->_service->isReferenceChanged($this);
+        if ($this->isModified() || $this->isPublished()) return false;
+
+        if ($this->reference && !$ignoreReference) {
+            return $this->_service->isReferenceChanged($this);
         }
 
-        return $this->_service->hasTmMisalignments($this);
+        return $this->_service->checkTmMisalignments($this);
     }
 
     public function getTmMisalignmentFile()
@@ -244,7 +246,6 @@ class FileModel extends Model
         if ($this->isComplete()) {
             $draft = Translations::$plugin->draftRepository->getDraftById($this->draftId, $targetSite);
             $targetElement = $draft ?: $targetElement;
-            // $source = $this->target;
         }
 
         if ($element instanceof GlobalSet) {
@@ -267,11 +268,11 @@ class FileModel extends Model
             'targetElement' => $targetElement,
             'targetElementSite' => $targetSite
         ];
-        $fileContent = Translations::$plugin->elementToFileConverter->createTmFileContent($TmData);
 
         return [
             'fileName' => $filename,
-            'fileContent' => $fileContent
+            'fileContent' => Translations::$plugin->fileRepository->createReferenceData($TmData),
+            'reference' => Translations::$plugin->fileRepository->createReferenceData($TmData, false),
         ];
     }
 }

--- a/src/services/ElementToFileConverter.php
+++ b/src/services/ElementToFileConverter.php
@@ -376,32 +376,4 @@ class ElementToFileConverter
 
         return $headers."\n".$content;
     }
-
-    /**
-     * Create a csv file for Translations memory alignments
-     *
-     * @var array $data
-     * @return string
-     */
-    public function createTmFileContent($data) {
-        $sourceLanguage = Craft::$app->sites->getSiteById($data['sourceElementSite'])->language;
-        $targetLanguage = Craft::$app->sites->getSiteById($data['targetElementSite'])->language;
-
-        $tmContent = sprintf('"key","%s","%s"', $sourceLanguage, $targetLanguage);
-
-        $source = json_decode($this->xmlToJson($data['sourceContent']), true)['content'] ?? [];
-
-        $target = Translations::$plugin->elementTranslator->toTranslationSource(
-            $data['targetElement'],
-            $data['targetElementSite']
-        );
-
-        foreach ($source as $key => $value) {
-            $targetValue = $target[$key] ?? '';
-            if ($value !== $targetValue)
-                $tmContent .= "\n" . sprintf('"%s","%s","%s"', $key, $value, $targetValue);
-        }
-
-        return $tmContent;
-    }
 }

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -183,6 +183,10 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
+        if ($file->isComplete()) {
+            $file->reference = null;
+        }
+
         $translation_service = $this->order->translator->service;
         if ($translation_service !== Constants::TRANSLATOR_DEFAULT) {
             $translation_service = Constants::TRANSLATOR_DEFAULT;
@@ -315,6 +319,10 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
+        if ($file->isComplete()) {
+            $file->reference = null;
+        }
+
         $translation_service = $this->order->translator->service;
         if ($translation_service !== Constants::TRANSLATOR_DEFAULT) {
             $translation_service = Constants::TRANSLATOR_DEFAULT;
@@ -416,6 +424,10 @@ class ImportFiles extends BaseJob
             $this->log(sprintf("File {%s} %s", $this->assetName($asset), $message));
 
             return $file->isModified() ? false : '';
+        }
+
+        if ($file->isComplete()) {
+            $file->reference = null;
         }
 
         $translation_service = $this->order->translator->service;

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -27,6 +27,7 @@ class ImportFiles extends BaseJob
     public $totalFiles;
     public $fileFormat;
     public $discardElements;
+    private $_allowAppliedChanges = null;
 
     /**
      * Map of assetId v/s file name
@@ -620,6 +621,9 @@ class ImportFiles extends BaseJob
 
     private function canProcessPublishedOrder()
     {
-        return $this->order->isPublished() && $this->order->hasDefaultTranslator();
+        if (is_null($this->_allowAppliedChanges))
+            $this->_allowAppliedChanges = $this->order->isPublished() && $this->order->hasDefaultTranslator();
+
+        return $this->_allowAppliedChanges;
     }
 }

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -22,6 +22,7 @@ class ImportFiles extends BaseJob
 {
     public $assets;
     public $orderId;
+    /** @var \acclaro\translations\elements\Order $order */
     public $order;
     public $totalFiles;
     public $fileFormat;
@@ -141,7 +142,7 @@ class ImportFiles extends BaseJob
             return false;
         }
 
-        foreach ($this->order->files as $orderFile)
+        foreach ($this->order->getFiles() as $orderFile)
         {
             if (
                 $elementId == $orderFile->elementId &&
@@ -173,7 +174,7 @@ class ImportFiles extends BaseJob
             return false;
         }
 
-        if ($file->isPublished() || $file->isModified()) {
+        if ((!$this->canProcessPublishedOrder() && $file->isPublished()) || $file->isModified()) {
             $message = 'has already been published.';
             if ($file->isModified()) {
                 $message = 'has been modified, please download again and try with latest files.';
@@ -275,7 +276,7 @@ class ImportFiles extends BaseJob
 
         $orderId = (string)$element->getAttribute('orderId');
 
-        foreach ($this->order->files as $orderFile)
+        foreach ($this->order->getFiles() as $orderFile)
         {
             if (
                 $orderId == $orderFile->orderId &&
@@ -308,8 +309,8 @@ class ImportFiles extends BaseJob
             return false;
         }
 
-        // Don't process published files
-        if ($file->isPublished() || $file->isModified()) {
+        // Don't process published files untill orders status is published
+        if ((!$this->canProcessPublishedOrder() && $file->isPublished()) || $file->isModified()) {
             $message = 'has already been published.';
             if ($file->isModified()) {
                 $message = 'has been modified, please download again and try with latest files.';
@@ -382,7 +383,7 @@ class ImportFiles extends BaseJob
             return false;
         }
 
-        foreach ($this->order->files as $orderFile)
+        foreach ($this->order->getFiles() as $orderFile)
         {
             if (
                 $elementId == $orderFile->elementId &&
@@ -416,7 +417,7 @@ class ImportFiles extends BaseJob
             return false;
         }
 
-        if ($file->isPublished() || $file->isModified()) {
+        if ((!$this->canProcessPublishedOrder() && $file->isPublished()) || $file->isModified()) {
             $message = 'has already been published.';
             if ($file->isModified()) {
                 $message = 'has been modified, please download again and try with latest files.';
@@ -615,5 +616,10 @@ class ImportFiles extends BaseJob
     private function assetName($asset)
     {
         return $this->fileNames[$asset->id] ?? $asset->getFilename();
+    }
+
+    private function canProcessPublishedOrder()
+    {
+        return $this->order->isPublished() && $this->order->hasDefaultTranslator();
     }
 }

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -198,6 +198,10 @@ class DraftRepository
                         ->makeTranslationService($translation_service, $order->translator->getSettings());
 
                     $translationService->updateIOFile($order, $file);
+
+                    $file->reference = null;
+
+                    Translations::$plugin->fileRepository->saveFile($file);
                 }
 
                 /**
@@ -270,7 +274,6 @@ class DraftRepository
             $file->draftId = $draft->draftId;
             $file->previewUrl = Translations::$plugin->urlGenerator->generateElementPreviewUrl($draft, $targetSite);
             $file->status = Constants::FILE_STATUS_COMPLETE;
-            $file->reference = null;
 
             Translations::$plugin->fileRepository->saveFile($file);
 

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -297,7 +297,7 @@ class AcclaroTranslationService implements TranslationServiceInterface
                 $path
             );
 
-            $file->reference = $tmFile['fileContent'];
+            $file->reference = $tmFile['reference'];
             Translations::$plugin->fileRepository->saveFile($file);
 
             fclose($stream);


### PR DESCRIPTION
# Fixed
1. Tm alert showed after source updated sync.
2. Applied files reverting to `In progress` when downloaded.
3. Upload translated files on `applied` order for `local` translator.