### PR TITLE
fix: tm alert on importing translations

### DIFF
--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -225,8 +225,6 @@ class FileModel extends Model
 
     public function hasTmMisalignments($ignoreReference = false)
     {
-        if ($this->isModified() || $this->isPublished()) return false;
-
         // Reference or miss alignment can only be check if source entry exists in given target site
         if (!Craft::$app->elements->getElementById($this->elementId, null, $this->targetSite)) {
             return false;
@@ -236,7 +234,7 @@ class FileModel extends Model
             return $this->_service->isReferenceChanged($this);
         }
 
-        if ($this->isNew() || $this->isComplete()) {
+        if ($ignoreReference || $this->isNew() || $this->isComplete()) {
             return $this->_service->checkTmMisalignments($this);
         }
 

--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -236,7 +236,11 @@ class FileModel extends Model
             return $this->_service->isReferenceChanged($this);
         }
 
-        return $this->_service->checkTmMisalignments($this);
+        if ($this->isNew() || $this->isComplete()) {
+            return $this->_service->checkTmMisalignments($this);
+        }
+
+        return false;
     }
 
     public function getTmMisalignmentFile()

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -185,7 +185,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 
@@ -321,7 +321,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 
@@ -428,7 +428,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 


### PR DESCRIPTION
# Fixed
- Tm alert being showed in order details page when importing updated translations on applied order ([AcclaroInc/#484](https://github.com/AcclaroInc/pm-craft-translations/issues/484))