### PR TITLE
Release/2.2.1

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "2.2.0",
+    "pluginVersion": "2.2.1",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.1 - 2022-06-24
+
+### Fixed
+
+- TM alignment error parsing special characters ([AcclaroInc/#483](https://github.com/AcclaroInc/pm-craft-translations/issues/483))
+- Track target content notice bug ([AcclaroInc/#484](https://github.com/AcclaroInc/pm-craft-translations/issues/484))
+- TM alignment file export bug ([AcclaroInc/485](https://github.com/AcclaroInc/pm-craft-translations/issues/485))
+
+### Updated
+
+- `craftcms/cms` minimum version from `3.7.33` to `3.7.36` due to dependency vulnerabilities
+- `guzzlehttp/guzzle` minimum version from `6.5.7` to `6.5.8` due to dependency vulnerabilities
+
 ## 2.2.0 - 2022-06-21
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.7.33",
-        "guzzlehttp/guzzle": "^6.5.7|^7.0",
+        "craftcms/cms": "^3.7.36",
+        "guzzlehttp/guzzle": "^6.5.8|^7.0",
         "php": ">=7.2.0",
         "sebastian/diff": "^3.0",
         "composer/composer": "^2.1.9",

--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -117,7 +117,8 @@ class FilesController extends Controller
                     Craft::error( '['. __METHOD__ .'] There was an error adding the file '.$fileName.' to the zip: '.$zipName, 'translations' );
                 }
 
-                if ($hasMisalignment) {
+                /** Check if entry exists in target site for reference comparison */
+                if ($hasMisalignment && Translations::$plugin->elementRepository->getElementById($file->elementId, $file->targetSite)) {
                     $tmFile = $file->getTmMisalignmentFile();
                     $fileName = $tmFile['fileName'];
 

--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -225,8 +225,6 @@ class FileModel extends Model
 
     public function hasTmMisalignments($ignoreReference = false)
     {
-        if ($this->isModified() || $this->isPublished()) return false;
-
         // Reference or miss alignment can only be check if source entry exists in given target site
         if (!Craft::$app->elements->getElementById($this->elementId, null, $this->targetSite)) {
             return false;
@@ -236,7 +234,11 @@ class FileModel extends Model
             return $this->_service->isReferenceChanged($this);
         }
 
-        return $this->_service->checkTmMisalignments($this);
+        if ($ignoreReference || $this->isNew() || $this->isComplete()) {
+            return $this->_service->checkTmMisalignments($this);
+        }
+
+        return false;
     }
 
     public function getTmMisalignmentFile()

--- a/src/services/job/ImportFiles.php
+++ b/src/services/job/ImportFiles.php
@@ -185,7 +185,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 
@@ -321,7 +321,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 
@@ -428,7 +428,7 @@ class ImportFiles extends BaseJob
             return $file->isModified() ? false : '';
         }
 
-        if ($file->isComplete()) {
+        if ($file->isComplete() || $file->isPublished()) {
             $file->reference = null;
         }
 


### PR DESCRIPTION
### Fixed

- TM alignment error parsing special characters ([AcclaroInc/#483](https://github.com/AcclaroInc/pm-craft-translations/issues/483))
- Track target content notice bug ([AcclaroInc/#484](https://github.com/AcclaroInc/pm-craft-translations/issues/484))
- TM alignment file export bug ([AcclaroInc/485](https://github.com/AcclaroInc/pm-craft-translations/issues/485))

### Updated

- `craftcms/cms` minimum version from `3.7.33` to `3.7.36` due to dependency vulnerabilities
- `guzzlehttp/guzzle` minimum version from `6.5.7` to `6.5.8` due to dependency vulnerabilities