### PR TITLE
fix: preview url column changed to text

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -4,7 +4,7 @@ namespace acclaro\translations;
 
 class Constants
 {
-    const PLUGIN_SCHEMA_VERSION = '1.3.8';
+    const PLUGIN_SCHEMA_VERSION = '1.3.9';
     const CRAFT_MIN_VERSION = '3.7.33';
     const WORD_COUNT_LIMIT  = 2000;
     const PLUGIN_HANDLE     = 'translations';
@@ -83,7 +83,7 @@ class Constants
     const DEFAULT_TAG   = 'CraftCMS';
 
     const ORDER_TAG_GROUP_HANDLE    = "craftTranslations";
-    const ACCLARO_TARGET_FILE_TYPE  = 'target';
+    const ACCLARO_SOURCE_FILE_TYPE  = 'source';
 
     // Acclaro Order Comments
     const ACCLARO_FILE_NEW      = 'NEW FILE';

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -5,7 +5,7 @@ namespace acclaro\translations;
 class Constants
 {
     const PLUGIN_SCHEMA_VERSION = '1.3.9';
-    const CRAFT_MIN_VERSION = '3.7.33';
+    const CRAFT_MIN_VERSION = '3.7.36';
     const WORD_COUNT_LIMIT  = 2000;
     const PLUGIN_HANDLE     = 'translations';
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -84,7 +84,7 @@ class Install extends Migration
                     'source'            => $this->longText(),
                     'reference'         => $this->longText(),
                     'target'            => $this->longText(),
-                    'previewUrl'        => $this->string()->defaultValue(''),
+                    'previewUrl'        => $this->text(),
                     'serviceFileId'     => $this->string()->defaultValue(''),
                     'dateCreated'       => $this->dateTime()->notNull(),
                     'dateUpdated'       => $this->dateTime()->notNull(),

--- a/src/migrations/m220705_040234_change_preview_url_column_to_text.php
+++ b/src/migrations/m220705_040234_change_preview_url_column_to_text.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace acclaro\translations\migrations;
+
+use craft\db\Migration;
+use acclaro\translations\Constants;
+
+/**
+ * m220705_040234_change_preview_url_column_to_text migration.
+ */
+class m220705_040234_change_preview_url_column_to_text extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        echo "Altering translations_files previewUrl column...\n";
+        $this->alterColumn(Constants::TABLE_FILES, 'previewUrl', $this->text());
+        echo "Done altering translations_files previewUrl column...\n";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m220705_040234_change_preview_url_column_to_text cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/services/api/AcclaroApiClient.php
+++ b/src/services/api/AcclaroApiClient.php
@@ -426,8 +426,7 @@ class AcclaroApiClient
     public function getFileInfo($orderId)
     {
         return $this->get(Constants::ACCLARO_API_GET_ORDER_FILES_INFO, array(
-            'orderid'   => $orderId,
-            'filetype'  => Constants::ACCLARO_TARGET_FILE_TYPE,
+            'orderid'   => $orderId
         ));
     }
 

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -137,6 +137,9 @@ class AcclaroTranslationService implements TranslationServiceInterface
 
             /** @var object $fileInfo */
             if (empty($fileInfo->targetfile)) {
+                if ($fileInfo->filetype == Constants::ACCLARO_SOURCE_FILE_TYPE) {
+                    Craft::error('[' . __METHOD__ . '] target file missing for fileId: ' . $file->id , 'translations');
+                }
                 return;
             }
 


### PR DESCRIPTION
### Fixed
- An issue where order fails to open when preview url length exceeds 255 chars. ([AcclaroInc/#482](https://github.com/AcclaroInc/pm-craft-translations/issues/482)) 

### Updated
- Removed the use of `filetype` param in api order sync call.
- Minimum required craft version.