### PR TITLE
Hotfix xml key mismatch old orders after update

### DIFF
--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -501,8 +501,8 @@ class FilesController extends Controller
         $files = json_decode(Craft::$app->getRequest()->getBodyParam('files'), true);
         $order = Translations::$plugin->orderRepository->getOrderById($orderId);
 
-        //Iterate over each file on this order
-        if ($order->files) {
+        //Iterate over each file on this order and only process if trackTargetChanges is enabled
+        if ($order->files && $order->trackTargetChanges) {
             foreach ($order->getFiles() as $file) {
                 if (in_array($file->id, $files) && $file->hasTmMisalignments()) {
                     $translationService = Translations::$plugin->translatorFactory->makeTranslationService(

--- a/src/services/fieldtranslator/MatrixFieldTranslator.php
+++ b/src/services/fieldtranslator/MatrixFieldTranslator.php
@@ -87,12 +87,15 @@ class MatrixFieldTranslator extends GenericFieldTranslator
         $new = 0;
         foreach ($blocks as $i => $block) {
             $i = sprintf('new%s', ++$new);
+
+            // Check for old key in case an order was created before plugin update
+            $oldKey = sprintf('%s_%s', $block->fieldId, $block->canonicalId);
             /**
              * Block id changes for localised block so use $i and using same for non localised blocks merges other
              * sites non localised block to non localised block.
              */
             $blockId = $field->getIsTranslatable() ? $i : $block->id;
-            $blockData = isset($fieldData[$i]) ? $fieldData[$i] : array();
+            $blockData = $fieldData[$i] ?? $fieldData[$oldKey] ?? array();
 
             $post[$fieldHandle][$blockId] = array(
                 'type'              => $block->getType()->handle,

--- a/src/services/fieldtranslator/NeoFieldTranslator.php
+++ b/src/services/fieldtranslator/NeoFieldTranslator.php
@@ -60,7 +60,7 @@ class NeoFieldTranslator extends GenericFieldTranslator
         $newToParse = array();
 
         foreach ($blockData as $key => $value) {
-            if (is_numeric($key) || strpos($key, "new", 0) !== false) {
+            if (is_numeric($key) || strpos($key, "_") !== false || strpos($key, "new", 0) !== false) {
                 $newToParse[$key] = $value;
             } else {
                 $newBlockData[$key] = $value;
@@ -100,8 +100,12 @@ class NeoFieldTranslator extends GenericFieldTranslator
         $new = 0;
         foreach ($blocks as $i => $block) {
             $i = 'new' . ++$new;
+
+            // Check for old key in case an order was created before plugin update
+            $oldKey = sprintf('%s_%s', $block->fieldId, $block->canonicalId);
+
             $blockId = $field->getIsTranslatable() ? $i : $block->id;
-            $blockData = isset($allBlockData[$i]) ? $allBlockData[$i] : array();
+            $blockData = $allBlockData[$i] ?? $allBlockData[$oldKey] ?? array();
 
             $post[$fieldHandle][$blockId] = array(
                 'modified' => '1',

--- a/src/services/fieldtranslator/SuperTableFieldTranslator.php
+++ b/src/services/fieldtranslator/SuperTableFieldTranslator.php
@@ -103,7 +103,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 					foreach ($block as $key => $elem) {
 						$n = sprintf('new%s', ++$new);
 						$blockId = $elem->id ?? $n;
-						$blockData = isset($fieldData[$n]) ? $fieldData[$n] : array();
+						$blockData = $fieldData[$n] ?? $fieldData[$blockId] ?? array();
 						$post[$fieldHandle][$blockId] = array(
 							'type' => $blockType->id,
 							'fields' => $elementTranslator->toPostArray($elem, $blockData),
@@ -111,8 +111,8 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 					}
 				} else {
 					$n = sprintf('new%s', ++$new);
-					$blockData = isset($fieldData[$n]) ? $fieldData[$n] : array();
 					$blockId = $block-> id ?? $n;
+					$blockData = $fieldData[$n] ?? $fieldData[$blockId] ?? array();
 					$post[$fieldHandle][$blockId] = array(
 						'type' => $blockType->id,
 						'fields' => $elementTranslator->toPostArray($block, $blockData),
@@ -123,7 +123,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 				foreach ($blockElem as $key => $block) {
 					$n = sprintf('new%s', ++$new);
 					$blockId = $block-> id ?? $n;
-					$blockData = isset($fieldData[$n][$key]) ? $fieldData[$n][$key] : array();
+					$blockData = $fieldData[$n][$key] ?? $fieldData[$blockId][$key] ?? array();
 					$post[$fieldHandle][$blockId] = array(
 						'type' => $blockType->id,
 						'fields' => $elementTranslator->toPostArray($block, $blockData),
@@ -160,7 +160,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 					foreach ($block as $key => $elem) {
 						$n = sprintf('new%s', ++$new);
 						$blockId = $field->getIsTranslatable() ? $n : $elem->id;
-						$blockData = isset($fieldData[$n]) ? $fieldData[$n] : array();
+						$blockData = $fieldData[$n] ?? $fieldData[$elem->id] ?? array();
 						$post[$fieldHandle][$blockId] = array(
 							'type' => $blockType->id,
 							'fields' => $elementTranslator->toPostArrayFromTranslationTarget($elem, $sourceLanguage, $targetLanguage, $blockData, true),
@@ -168,8 +168,8 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 					}
 				} else {
 					$n = sprintf('new%s', ++$new);
-					$blockData = isset($fieldData[$n]) ? $fieldData[$n] : array();
 					$blockId = $field->getIsTranslatable() ? $n : $block->id;
+					$blockData = $fieldData[$n] ?? $fieldData[$block->id] ?? array();
 					$post[$fieldHandle][$blockId] = array(
 						'type' => $blockType->id,
 						'fields' => $elementTranslator->toPostArrayFromTranslationTarget($block, $sourceLanguage, $targetLanguage, $blockData, true),
@@ -180,7 +180,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 				foreach ($blockElem as $key => $block) {
 					$n = sprintf('new%s', ++$new);
 					$blockId = $field->getIsTranslatable() ? $n : $block->id;
-					$blockData = isset($fieldData[$n][$key]) ? $fieldData[$n][$key] : array();
+					$blockData = $fieldData[$n][$key] ?? $fieldData[$block->id][$key] ?? array();
 					$post[$fieldHandle][$blockId] = array(
 						'type' => $blockType->id,
 						'fields' => $elementTranslator->toPostArrayFromTranslationTarget($block, $sourceLanguage, $targetLanguage, $blockData, true),
@@ -188,6 +188,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 				}
 			}
 		}
+
 		return $post;
 	}
 

--- a/src/services/translator/Export_ImportTranslationService.php
+++ b/src/services/translator/Export_ImportTranslationService.php
@@ -109,7 +109,7 @@ class Export_ImportTranslationService implements TranslationServiceInterface
                 $draft->title = isset($targetData['title']) ? $targetData['title'] : $draft->title;
                 $draft->slug = isset($targetData['slug']) ? $targetData['slug'] : $draft->slug;
 
-				$post = Translations::$plugin->elementTranslator->toPostArrayFromTranslationTarget($draft, $sourceSite, $targetSite, $targetData);
+				$post = Translations::$plugin->elementTranslator->toPostArrayFromTranslationTarget($element, $sourceSite, $targetSite, $targetData);
                 $draft->setFieldValues($post);
                 $draft->siteId = $targetSite;
 


### PR DESCRIPTION
# Fixed
- Target missing from draft for orders that were created before update to v2.2.0 (xml resname keys are changed in this release)
- Tm files were getting synced for order that don't have track target changes enabled (i.e orders created before this feature was introduced)