### PR TITLE
Fix: revert allow local order setting from config settings

### DIFF
--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -98,10 +98,7 @@ class OrderController extends Controller
 		$variables['orientation'] = Craft::$app->getLocale()->orientation;
 		$variables['chkDuplicateEntries'] = Translations::getInstance()->settings->chkDuplicateEntries;
         $variables['tagGroup'] = Craft::$app->getTags()->getTagGroupByHandle(Constants::ORDER_TAG_GROUP_HANDLE);
-        $variables['allowLocalOrder'] =  Translations::getInstance()->settings->allowLocalOrder;
         $variables['apiLogging'] =  Translations::getInstance()->settings->apiLogging;
-
-        $variables['translatorOptions']=[];
 
         $variables['versionsByElementId'] = [];
         $variables['elements'] = [];
@@ -112,23 +109,8 @@ class OrderController extends Controller
 		$variables['isDefaultTranslator'] = true;
 		$variables['elementWordCounts'] = array();
         $variables['orderWordCount'] = 0;
-        $variables['translatorOption'] = Translations::$plugin->translatorRepository->getTranslatorOptions();
+        $variables['translatorOptions'] = Translations::$plugin->translatorRepository->getTranslatorOptions();
 
-
-        if(Translations::getInstance()->settings->allowLocalOrder==false){
-            foreach ($variables['translatorOption'] as $key => $value) {
-                if($key==1){
-                    continue;
-                }
-                else{
-                    $variables['translatorOptions'][$key]=$value;
-                }    
-               
-            }
-        }
-        else{
-            $variables['translatorOptions'] = Translations::$plugin->translatorRepository->getTranslatorOptions();
-        }
         if ($variables['isProcessing']) {
             $submitAction = Craft::$app->getRequest()->getParam('submit');
             if ($submitAction == "draft" || $submitAction == "publish") {
@@ -296,9 +278,6 @@ class OrderController extends Controller
                 $translator = Translations::$plugin->translatorRepository->getTranslatorById($translatorId);
 
                 if ($translator->service === Constants::TRANSLATOR_DEFAULT) {
-                    $variables['defaultTranslatorId'] = $translatorId;
-                }
-                else{
                     $variables['defaultTranslatorId'] = $translatorId;
                 }
             }

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -212,7 +212,6 @@ class SettingsController extends Controller
         $variables['trackSourceChanges'] = $settings->trackSourceChanges;
         $variables['trackTargetChanges'] = $settings->trackTargetChanges;
         $variables['apiLogging'] = $settings->apiLogging;
-        $variables['allowLocalOrder'] = $settings->allowLocalOrder;
         $variables['uploadVolume'] = $settings->uploadVolume;
         $variables['twigSearchFilterSingleQuote'] = !empty($settings->twigSearchFilterSingleQuote) ? $settings->twigSearchFilterSingleQuote : "";
         $variables['twigSearchFilterDoubleQuote'] = !empty($settings->twigSearchFilterDoubleQuote) ? $settings->twigSearchFilterDoubleQuote : "";
@@ -248,7 +247,6 @@ class SettingsController extends Controller
         $trackSourceChanges = $request->getParam('trackSourceChanges');
         $trackTargetChanges = $request->getParam('trackTargetChanges');
         $apiLogging = $request->getParam('apiLogging');
-        $allowLocalOrder = $request->getParam('allowLocalOrder');
         $selectedVolume = $request->getParam('uploadVolume');
         $twigSearchFilterSingleQuote = $request->getParam('twigSearchFilterSingleQuote');
         $twigSearchFilterDoubleQuote = $request->getParam('twigSearchFilterDoubleQuote');
@@ -264,7 +262,6 @@ class SettingsController extends Controller
                 'trackSourceChanges'            => $trackSourceChanges,
                 'trackTargetChanges'            => $trackTargetChanges,
                 'apiLogging'		            => $apiLogging,
-                'allowLocalOrder'               => $allowLocalOrder,
                 'uploadVolume'                  => $selectedVolume,
                 'twigSearchFilterSingleQuote'   => $twigSearchFilterSingleQuote,
                 'twigSearchFilterDoubleQuote'   => $twigSearchFilterDoubleQuote,

--- a/src/models/FileModel.php
+++ b/src/models/FileModel.php
@@ -133,7 +133,7 @@ class FileModel extends Model
 
     public function hasDraft()
     {
-        return $this->draftId ?: null;
+        return $this->_service->getDraft($this);
     }
 
     public function isNew()

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,8 +27,6 @@ class Settings extends Model
 
     public $apiLogging;
 
-    public $allowLocalOrder;
-
     public $twigSearchFilterSingleQuote = "";
 
     public $twigSearchFilterDoubleQuote = "";

--- a/src/services/Exporter.php
+++ b/src/services/Exporter.php
@@ -103,9 +103,6 @@ class Exporter extends ElementExporter
 
             $attributeArr = [];
             foreach ($order as $key => $value){
-                if($key=='status') {
-                    $value = ucwords($value);
-                }
                 $attributeArr[ucfirst($key)] = $value;
             }
             $rawData[] = $attributeArr;

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -178,7 +178,7 @@ class DraftRepository
             }
 
 			// Create draft only if not already exist
-			if ($file->draftId && $this->getDraftById($file->draftId, $file->targetSite)) {
+			if ($file->hasDraft()) {
                 $file->status = Constants::FILE_STATUS_COMPLETE;
                 Translations::$plugin->fileRepository->saveFile($file);
 			} else {
@@ -265,12 +265,6 @@ class DraftRepository
         }
 
         try {
-            // Prevent duplicate files
-            $isExistingFile = $this->isTranslationDraft($draft->draftId);
-            if (!empty($isExistingFile)) {
-                return;
-            }
-
             $file->draftId = $draft->draftId;
             $file->previewUrl = Translations::$plugin->urlGenerator->generateElementPreviewUrl($draft, $targetSite);
             $file->status = Constants::FILE_STATUS_COMPLETE;

--- a/src/services/repository/FileRepository.php
+++ b/src/services/repository/FileRepository.php
@@ -528,6 +528,31 @@ class FileRepository
         return false;
     }
 
+    // Draft Actions
+
+    public function getDraft(FileModel $file)
+    {
+        $draft = null;
+
+        if ($file->draftId && $element = $file->getElement()) {
+            switch (get_class($element)) {
+                case GlobalSet::class:
+                    $draft = Translations::$plugin->globalSetDraftRepository->getDraftById($file->draftId);
+                    break;
+                case Category::class:
+                    $draft = Translations::$plugin->categoryDraftRepository->getDraftById($file->draftId);
+                    break;
+                case Asset::class:
+                    $draft = Translations::$plugin->assetDraftRepository->getDraftById($file->draftId);
+                    break;
+                default:
+                    $draft = Translations::$plugin->draftRepository->getDraftById($file->draftId, $file->targetSite);
+            }
+        }
+
+        return $draft;
+    }
+
     public function createReferenceData(array $data, $ignoreCommon = true)
     {
         $sourceLanguage = Craft::$app->sites->getSiteById($data['sourceElementSite'])->language;

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -495,7 +495,7 @@ class OrderRepository
             $draftElement = Translations::$plugin->draftRepository->getDraftById($file->draftId, $file->targetSite);
         }
 
-		return $draftElement->title ?? $element->title;
+		return $draftElement->title ?? $draftElement->name ?? $element->title;
     }
 
     /**

--- a/src/services/repository/TranslatorRepository.php
+++ b/src/services/repository/TranslatorRepository.php
@@ -13,7 +13,6 @@ namespace acclaro\translations\services\repository;
 use Craft;
 use Exception;
 use acclaro\translations\Constants;
-use acclaro\translations\elements\Translator;
 use acclaro\translations\models\TranslatorModel;
 use acclaro\translations\records\TranslatorRecord;
 
@@ -28,7 +27,7 @@ class TranslatorRepository
         $record = TranslatorRecord::findOne($translatorId);
 
         if (! $record) return null;
-        
+
         $translator = new TranslatorModel($record->toArray([
             'id',
             'label',
@@ -41,7 +40,7 @@ class TranslatorRepository
 
         return $translator;
     }
-    
+
     /**
      * @param  int|string $service
      * @return \acclaro\translations\models\TranslatorModel
@@ -50,7 +49,7 @@ class TranslatorRepository
     {
         $records = TranslatorRecord::find()->all();
         $translators = array();
-        
+
         foreach ($records as $key => $record) {
             $translators[$key] = new TranslatorModel($record->toArray([
                 'id',
@@ -65,7 +64,7 @@ class TranslatorRepository
 
         return $translators;
     }
-    
+
     /**
      * @return array \acclaro\translations\models\TranslatorModel
      */
@@ -73,7 +72,7 @@ class TranslatorRepository
     {
         $records = TranslatorRecord::find()->all();
         $translators = array();
-        
+
         foreach ($records as $key => $record) {
             $translators[$key] = new TranslatorModel($record->toArray([
                 'id',
@@ -150,14 +149,13 @@ class TranslatorRepository
         }
 
         return $options;
-        // return $this->getActiveTranslators();
     }
 
     /**
      * @return slug => label
      */
     public function getTranslationServices()
-    {  
+    {
         return array(
             'acclaro' => 'Acclaro',
             'export_import' =>'Export/Import',
@@ -233,7 +231,7 @@ class TranslatorRepository
     public function deleteTranslator(TranslatorModel $translator)
     {
         $record = TranslatorRecord::findOne($translator->id);
-        
+
         $transaction = Craft::$app->db->getTransaction() === null ? Craft::$app->db->beginTransaction() : null;
 
         try {

--- a/src/templates/_components/orders/info-tab.twig
+++ b/src/templates/_components/orders/info-tab.twig
@@ -29,8 +29,7 @@
 		<div class="input ltr">
 			<div class="float-right">
 			{% if orderId %}
-				<a class="right" href="{{ url('translations/translators/detail/'~order.translatorId) }}"
-				> {{ translatorOption[order.translatorId] }} </a>
+				<a class="right" href="{{ url('translations/translators/detail/'~order.translatorId) }}"> {{ translatorOptions[order.translatorId] }} </a>
 			{% else %}
 				<label class="right"> {{ "N/A" }} </label>
 			{% endif %}

--- a/src/templates/settings/configuration-options.twig
+++ b/src/templates/settings/configuration-options.twig
@@ -107,17 +107,6 @@
             name: 'apiLogging',
             on: apiLogging,
         }) }}
-        <hr>
-        <h3>{{ "Local order"|t('app') }}</h3>
-
-        {{ forms.lightswitchField({
-            first: true,
-            label: "Enable local order"|t('app'),
-            instructions: "Creates a local order."|t('app'),
-            id: 'allowLocalOrder',
-            name: 'allowLocalOrder',
-            on: allowLocalOrder,
-        }) }}
 
         <div class="buttons">
             <input type="submit" id="save-configuration" class="btn" value="{{ "Save"|t('app') }}" />
@@ -129,7 +118,7 @@
 
 {% js %}
     $( document ).ready(function() {
-        $('#chkDuplicateEntries, #apiLogging, #trackSourceChanges,#allowLocalOrder, #trackTargetChanges').change(function() {
+        $('#chkDuplicateEntries, #apiLogging, #trackSourceChanges, #trackTargetChanges').change(function() {
             $('#save-configuration').toggleClass('submit');
         });
     });


### PR DESCRIPTION
### Fixed
- Removed changes for allowing a config setting to enable and disabled local translator.
- An error merging into draft where same draft id was conflicting for global set, category and assets drafts.
- An issue where global set title was not visible on file tab on order details page.