### PR TITLE
Fix category draft issue and refactor

### DIFF
--- a/src/assetbundles/src/js/OrderEntries.js
+++ b/src/assetbundles/src/js/OrderEntries.js
@@ -8,6 +8,7 @@
 	var hasOrderId = $("input[type=hidden][name=id]").val() != '';
 	var isInProgress = $("#order-attr").data("status") === "in progress";
 	var hasCompleteFiles = $("#order-attr").data("has-completed-file");
+	var isTmAligned = $("#order-attr").data("is-tm-aligned");
 
 	/**
 	 * Order entries class
@@ -473,6 +474,7 @@
 
             $downloadTmAction = $('<a>', {
                 'href': '#',
+                'class': isTmAligned ? 'link-disabled' : '',
                 'text': $label,
             });
             $downloadTmLi.append($downloadTmAction);

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -683,16 +683,18 @@ class Order extends Element
 
     public function shouldTrackSourceContent()
     {
-        if ($this->trackChanges === NULL) return Translations::getInstance()->settings->trackSourceChanges;
+        if (!$this->id) {
+            return Translations::getInstance()->settings->trackSourceChanges;
+        }
 
-        return (bool) $this->trackChanges;
+        return $this->trackChanges;
     }
 
     public function shouldTrackTargetContent()
     {
-        if ($this->trackTargetChanges === NULL) return Translations::getInstance()->settings->trackTargetChanges;
+        if (! $this->id) return Translations::getInstance()->settings->trackTargetChanges;
 
-        return (bool) $this->trackTargetChanges;
+        return $this->trackTargetChanges;
     }
 
 	public function isExportImportAllowed()

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -557,7 +557,7 @@ class OrderRepository
 		$originalIds = [];
 
 		foreach ($order->getFiles() as $file) {
-			if ($file->isPublished() || $file->isNew()) continue;
+			if ($file->isPublished() || $file->isNew() || $file->isModified()) continue;
 
 			if ($file->hasTmMisalignments()) array_push($originalIds, $file->elementId);
 		}

--- a/src/templates/orders/_detail.twig
+++ b/src/templates/orders/_detail.twig
@@ -27,6 +27,7 @@
                 <input type="hidden" id="order-attr" data-status="{{ orderRecentStatus|default('pending') }}" data-isUpdateable="{{ isUpdateable|default('') }}"
                 data-submitted="{{ isSubmitted }}" data-changed="{{ isChanged }}"
 				data-has-completed-file="{{ order.hasCompletedFiles }}"
+				data-is-tm-aligned = "{{ isTargetChanged is empty }}"
 				data-translator="{{ order.translator.service|default('export_import') }}"/>
 				<div id="new-order-button-group" class="btngroup submit"></div>
 			</div>


### PR DESCRIPTION
### Fixed
- A bug where global config settings for track source/target changes was interfering with submitted orders track changes light switch.

### Update
- Download/Sync TM files option only available when user can see alert icon for target mismatch.