### PR TITLE
fix: catch error when newsfeed is unreachable

### DIFF
--- a/src/widgets/News.php
+++ b/src/widgets/News.php
@@ -115,7 +115,13 @@ class News extends Widget
             'verify' => false
         ));
 
-        $response = $client->get('feed/');
+        try {
+            $response = $client->get('feed/');
+        } catch (\Throwable $e) {
+            Craft::$app->getErrorHandler()->logException($e);
+            return [];
+        }
+
         $data = $response->getBody()->getContents();
         $feed = simplexml_load_string($data);
 


### PR DESCRIPTION
If the newsfeed at acclaro.com is ever unavailable, fail gracefully and show an empty newsfeed.