### PR TITLE
fixed: error opening plugin settings page

### DIFF
--- a/src/Translations.php
+++ b/src/Translations.php
@@ -279,7 +279,7 @@ class Translations extends Plugin
     public function getSettingsResponse(): mixed
     {
         // Just redirect to the plugin settings page
-        Craft::$app->getResponse()->redirect(UrlHelper::cpUrl(Constants::URL_SETTINGS));
+        return Craft::$app->getResponse()->redirect(UrlHelper::cpUrl(Constants::URL_SETTINGS));
     }
 
     protected function createSettingsModel(): ?\craft\base\Model


### PR DESCRIPTION
### Fixed
- Plugin settings url throwing error ([AcclaoInc#497](https://github.com/AcclaroInc/pm-craft-translations/issues/497))