### PR TITLE
Release/3.2.6

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "3.2.5",
+    "pluginVersion": "3.2.6",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.6 - 2023-05-29
+
+### Added
+- Dedicated `prevent slug translation` button if user does not want slug translation. ([AcclaroInc#436](https://github.com/AcclaroInc/craft-translations/issues/436))
+
+### Fixed
+- An issue where plugin license was always showing `free trial` despite of `Paid` even after license is purchased. ([AcclaroInc#437](https://github.com/AcclaroInc/craft-translations/issues/437))
+- An issue where asset's title was incuded in source files regardless of translation enabled or not. ([AcclaroInc#439](https://github.com/AcclaroInc/craft-translations/issues/439))
+
 ## 3.2.5 - 2023-04-15
 
 ### Fixed

--- a/src/assetbundles/src/js/OrderDetails.js
+++ b/src/assetbundles/src/js/OrderDetails.js
@@ -194,6 +194,7 @@
         title = $('#title').val();
 		trackChanges = $('input[type=hidden][name=trackChanges]').val();
 		trackTargetChanges = $('input[type=hidden][name=trackTargetChanges]').val();
+		preventSlugTranslation = $('input[type=hidden][name=preventSlugTranslation]').val();
 		includeTmFiles = $('input[type=hidden][name=includeTmFiles]').val();
 		requestQuote = $('input[type=hidden][name=requestQuote]').val();
         tags = $('input[name="tags[]"]');
@@ -232,6 +233,7 @@
 
         if (trackChanges) url += "&trackChanges=" + trackChanges
         if (trackTargetChanges) url += "&trackTargetChanges=" + trackTargetChanges
+        if (preventSlugTranslation) url += "&preventSlugTranslation=" + preventSlugTranslation
         if (includeTmFiles) url += "&includeTmFiles=" + includeTmFiles
         if (requestQuote) url += "&requestQuote=" + requestQuote
 

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -193,6 +193,10 @@ class OrderController extends BaseController
 				$order->trackTargetChanges = $orderTrackTargetChanges;
 			}
 
+			if ($orderPreventSlugTranslation = Craft::$app->getRequest()->getQueryParam('preventSlugTranslation')) {
+				$order->preventSlugTranslation = $orderPreventSlugTranslation;
+			}
+
 			if ($orderIncludeTmFiles = Craft::$app->getRequest()->getQueryParam('includeTmFiles')) {
 				$order->includeTmFiles = $orderIncludeTmFiles;
 			}
@@ -677,6 +681,7 @@ class OrderController extends BaseController
         $newOrder->title = $data['title'] ?? '';
         $newOrder->trackChanges = $variables['shouldTrackSourceContent'] = $data['trackChanges'] ?? null;
 		$newOrder->trackTargetChanges = $variables['shouldTrackTargetContent'] = $data['trackTargetChanges'] ?? null;
+		$newOrder->preventSlugTranslation = $variables['shouldPreventSlugTranslation'] = $data['preventSlugTranslation'] ?? null;
 		$newOrder->includeTmFiles = $data['includeTmFiles'] ?? null;
 		$newOrder->requestQuote = $data['requestQuote'] ?? null;
         $newOrder->targetSites = json_encode($data['targetSites'] ?? '');
@@ -937,6 +942,7 @@ class OrderController extends BaseController
 			$order->targetSites = json_encode($targetSites);
 			$order->trackChanges = Craft::$app->getRequest()->getBodyParam('trackChanges');
 			$order->trackTargetChanges = Craft::$app->getRequest()->getBodyParam('trackTargetChanges');
+			$order->preventSlugTranslation = Craft::$app->getRequest()->getBodyParam('preventSlugTranslation');
 			$order->includeTmFiles = Craft::$app->getRequest()->getBodyParam('includeTmFiles');
 			$translatorService->updateOrder($order);
 

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -443,6 +443,7 @@ class OrderController extends BaseController
             $order->trackChanges = Craft::$app->getRequest()->getBodyParam('trackChanges');
 			$order->trackTargetChanges = Craft::$app->getRequest()->getBodyParam('trackTargetChanges');
 			$order->includeTmFiles = Craft::$app->getRequest()->getBodyParam('includeTmFiles');
+            $order->preventSlugTranslation = Craft::$app->getRequest()->getBodyParam('preventSlugTranslation');
 			$order->requestQuote = Craft::$app->getRequest()->getBodyParam('requestQuote');
 			$order->sourceSite = $sourceSite;
             $order->targetSites = $targetSites ? json_encode($targetSites) : null;
@@ -1222,11 +1223,12 @@ class OrderController extends BaseController
             throw new HttpException(400, Translations::$plugin->translator
                 ->translate('app', 'Source site is not supported'));
         }
-        
-        $orderId = Craft::$app->getRequest()->getBodyParam('id');
-        $order = $this->service->getOrderById($orderId);
 
-        if (! $order->isPending()) {
+        $orderId = Craft::$app->getRequest()->getBodyParam('id');
+
+        if ($orderId && $this->service->getOrderById($orderId)->isPending()) {
+            $order = $this->service->getOrderById($orderId);
+        } else {
             $order = $this->service->makeNewOrder($sourceSite);
             $order->logActivity(Translations::$plugin->translator->translate('app', 'Order draft created'));
         }
@@ -1271,6 +1273,7 @@ class OrderController extends BaseController
             $order->title = $title;
             $order->trackChanges = Craft::$app->getRequest()->getBodyParam('trackChanges');
 			$order->trackTargetChanges = Craft::$app->getRequest()->getBodyParam('trackTargetChanges');
+            $order->preventSlugTranslation = Craft::$app->getRequest()->getBodyParam('preventSlugTranslation');
 			$order->includeTmFiles = Craft::$app->getRequest()->getBodyParam('includeTmFiles');
 			$order->requestQuote = Craft::$app->getRequest()->getBodyParam('requestQuote');
             $order->sourceSite = $sourceSite;

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -232,10 +232,11 @@ class SettingsController extends BaseController
         }
 
         $settings = Translations::getInstance()->settings;
-        $variables['chkDuplicateEntries'] = $settings->chkDuplicateEntries;
-        $variables['trackSourceChanges'] = $settings->trackSourceChanges;
-        $variables['trackTargetChanges'] = $settings->trackTargetChanges;
-        $variables['apiLogging'] = $settings->apiLogging;
+        $variables['chkDuplicateEntries'] = $settings->chkDuplicateEntries ?? '';
+        $variables['trackSourceChanges'] = $settings->trackSourceChanges ?? '';
+        $variables['trackTargetChanges'] = $settings->trackTargetChanges ?? '';
+        $variables['preventSlugTranslation'] = $settings->preventSlugTranslation ?? '';
+        $variables['apiLogging'] = $settings->apiLogging ?? '';
         $variables['uploadVolume'] = $settings->uploadVolume;
         $variables['twigSearchFilterSingleQuote'] = !empty($settings->twigSearchFilterSingleQuote) ? $settings->twigSearchFilterSingleQuote : "";
         $variables['twigSearchFilterDoubleQuote'] = !empty($settings->twigSearchFilterDoubleQuote) ? $settings->twigSearchFilterDoubleQuote : "";
@@ -244,10 +245,10 @@ class SettingsController extends BaseController
         $allVolumes = Craft::$app->getVolumes()->getAllVolumes();
 
         $variables['volumeOptions'] = array_map(function (Volume $volume) {
-        	return [
-        		'label' => $volume->name,
-        		'value' => $volume->id,
-        	];
+            return [
+                'label' => $volume->name,
+                'value' => $volume->id,
+            ];
         }, $allVolumes);
 
         // Add default temp uploads option
@@ -270,6 +271,7 @@ class SettingsController extends BaseController
         $duplicateEntries = $request->getParam('chkDuplicateEntries');
         $trackSourceChanges = $request->getParam('trackSourceChanges');
         $trackTargetChanges = $request->getParam('trackTargetChanges');
+        $preventSlugTranslation = $request->getParam('preventSlugTranslation');
         $apiLogging = $request->getParam('apiLogging');
         $selectedVolume = $request->getParam('uploadVolume');
         $twigSearchFilterSingleQuote = $request->getParam('twigSearchFilterSingleQuote');
@@ -285,6 +287,7 @@ class SettingsController extends BaseController
                 'chkDuplicateEntries'           => $duplicateEntries,
                 'trackSourceChanges'            => $trackSourceChanges,
                 'trackTargetChanges'            => $trackTargetChanges,
+                'preventSlugTranslation'        => $preventSlugTranslation,
                 'apiLogging'		            => $apiLogging,
                 'uploadVolume'                  => $selectedVolume,
                 'twigSearchFilterSingleQuote'   => $twigSearchFilterSingleQuote,

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -767,6 +767,13 @@ class Order extends Element
         return $this->trackTargetChanges;
     }
 
+    public function shouldPreventSlugTranslation()
+    {
+        if (! $this->id) return Translations::getInstance()->settings->preventSlugTranslation;
+
+        return $this->preventSlugTranslation;
+    }
+
     /**
      * Check if the order should be processed using queue
      */

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -83,6 +83,8 @@ class Order extends Element
 
     public $includeTmFiles;
 
+    public $preventSlugTranslation;
+
     public $asynchronousPublishing;
 
     public $requestQuote;
@@ -842,6 +844,11 @@ class Order extends Element
     {
         return $this->status === Constants::ORDER_STATUS_PUBLISHED;
     }
+    
+    public function isSlugTranslatable()
+    {
+        return !$this->preventSlugTranslation;
+    }
 
     public function requestQuote()
     {
@@ -890,6 +897,7 @@ class Order extends Element
         $record->tags =  $this->tags;
         $record->trackChanges =  $this->trackChanges;
 		$record->trackTargetChanges =  $this->trackTargetChanges;
+		$record->preventSlugTranslation =  $this->preventSlugTranslation;
 		$record->includeTmFiles =  $this->includeTmFiles;
 		$record->requestQuote =  $this->requestQuote;
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -159,6 +159,7 @@ class Install extends Migration
                     'trackChanges'              => $this->integer()->defaultValue(0),
 					'includeTmFiles'            => $this->integer()->defaultValue(0),
 					'trackTargetChanges'        => $this->integer()->defaultValue(0),
+                    'preventSlugTranslation'    => $this->integer()->defaultValue(0),
                     'asynchronousPublishing'    => $this->integer()->defaultValue(0),
                     'requestQuote'              => $this->integer()->defaultValue(0),
                     'dateCreated'               => $this->dateTime()->notNull(),

--- a/src/migrations/m230503_053114_add_prevent_slug_translation_column_to_orders_table.php
+++ b/src/migrations/m230503_053114_add_prevent_slug_translation_column_to_orders_table.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace acclaro\translations\migrations;
+
+use craft\db\Migration;
+use acclaro\translations\Constants;
+
+/**
+ * m230503_053114_add_prevent_slug_translation_column_to_orders_table migration.
+ */
+class m230503_053114_add_prevent_slug_translation_column_to_orders_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->addColumn(Constants::TABLE_ORDERS, 'preventSlugTranslation', $this->integer()->defaultValue(0)->after('trackTargetChanges'));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropColumn(Constants::TABLE_ORDERS, 'preventSlugTranslation');
+        return true;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -25,6 +25,8 @@ class Settings extends Model
 
     public $trackTargetChanges;
 
+    public $preventSlugTranslation;
+
     public $apiLogging;
 
     public $twigSearchFilterSingleQuote = "";

--- a/src/services/ElementToFileConverter.php
+++ b/src/services/ElementToFileConverter.php
@@ -46,7 +46,7 @@ class ElementToFileConverter
 
         $body = $xml->appendChild($dom->createElement('body'));
 
-        foreach (Translations::$plugin->elementTranslator->toTranslationSource($element, $sourceSite) as $key => $value) {
+        foreach (Translations::$plugin->elementTranslator->toTranslationSource($element, $sourceSite, $orderId) as $key => $value) {
             $translation = $dom->createElement('content');
 
             $translation->setAttribute('resname', $key);
@@ -81,7 +81,8 @@ class ElementToFileConverter
         foreach (
             Translations::$plugin->elementTranslator->toTranslationSource(
                 $element,
-                $sourceSite
+                $sourceSite,
+                $orderId
             ) as $key => $value
         ) {
             $file['content'][$key] = $value;
@@ -110,7 +111,8 @@ class ElementToFileConverter
         foreach (
             Translations::$plugin->elementTranslator->toTranslationSource(
                 $element,
-                $sourceSite
+                $sourceSite,
+                $orderId
             ) as $key => $value
         ) {
             $headers .= ",\"$key\"";
@@ -244,15 +246,15 @@ class ElementToFileConverter
      * @return string
      */
     private function reportXmlErrors() {
-    	$errors = array();
-    	$libErros = libxml_get_errors();
+        $errors = array();
+        $libErros = libxml_get_errors();
 
-    	$msg = false;
-    	if ($libErros && isset($libErros[0]))
-    	{
-    		$msg = $libErros[0]->code . ": " .$libErros[0]->message;
-    	}
-    	return $msg;
+        $msg = false;
+        if ($libErros && isset($libErros[0]))
+        {
+            $msg = $libErros[0]->code . ": " .$libErros[0]->message;
+        }
+        return $msg;
     }
 
     public function csvToJson($file_content)

--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -21,10 +21,11 @@ use acclaro\translations\Constants;
 use acclaro\translations\Translations;
 use craft\commerce\elements\Product;
 use craft\fields\Color;
+use acclaro\translations\services\repository\OrderRepository;
 
 class ElementTranslator
 {
-    public function toTranslationSource(Element $element, $sourceSite=null)
+    public function toTranslationSource(Element $element, $sourceSite = null, $orderId = null)
     {
         $source = array();
 
@@ -33,9 +34,17 @@ class ElementTranslator
                 $source['title'] = $element->title;
             }
             if ($element->slug) {
-                $source['slug'] = $element->slug;
+                switch (true) {
+                    case ($orderId):
+                        $order = (new OrderRepository())->getOrderById($orderId);
+                        if ($order && !$order->isSlugTranslatable()) {
+                            break;
+                        }
+                    default:
+                        $source['slug'] = $element->slug;
+                }
             }
-
+        
         }
 
         foreach ($element->getFieldLayout()->getCustomFields() as $layoutField) {

--- a/src/services/fieldtranslator/AssetsFieldTranslator.php
+++ b/src/services/fieldtranslator/AssetsFieldTranslator.php
@@ -29,9 +29,11 @@ class AssetsFieldTranslator extends GenericFieldTranslator
         {
             foreach ($blocks as $block)
             {
-                $source[sprintf('%s.%s.%s', $field->handle, $block->id, 'title')] = $block->title;
-
                 $element = Craft::$app->assets->getAssetById($block->id, $sourceSite);
+                if ($element->getIsTitleTranslatable()) {
+                    $source[sprintf('%s.%s.%s', $field->handle, $block->id, 'title')] = $block->title;
+                }
+
                 foreach ($element->getFieldLayout()->getCustomFields() as $layoutField) {
                     $assetField = Craft::$app->fields->getFieldById($layoutField->id);
                     $fieldSource = $elementTranslator->fieldToTranslationSource($element, $assetField, $sourceSite);

--- a/src/services/repository/FileRepository.php
+++ b/src/services/repository/FileRepository.php
@@ -481,7 +481,7 @@ class FileRepository
 
             $converter = Translations::$plugin->elementToFileConverter;
 
-            $currentContent = Translations::$plugin->elementTranslator->toTranslationSource($element, $sourceSite);
+            $currentContent = Translations::$plugin->elementTranslator->toTranslationSource($element, $sourceSite, $file->orderId);
             $currentContent = json_encode(array_map("strval", array_values($currentContent)));
 
             $sourceContent = json_decode($converter->xmlToJson($source), true);
@@ -621,7 +621,8 @@ class FileRepository
         
         $target = Translations::$plugin->elementTranslator->toTranslationSource(
             $data['targetElement'],
-            $data['targetElementSite']
+            $data['targetElementSite'],
+            $meta['orderId']
         );
         $tmContent = '';
 

--- a/src/templates/_components/_forms/order-entries-table.twig
+++ b/src/templates/_components/_forms/order-entries-table.twig
@@ -48,7 +48,7 @@
                                 {% set entryPreviewSettings = order.entryPreviewSettings(element) %}
                                 <div id="{{ entryPreviewSettings['id'] }}">
                                     <div class="elements">
-                                        <div class="element small" title="{{ element.uiLabel ~" - " ~siteObjects[order.sourceSite].name }}">
+                                        <div class="element flex" title="{{ element.uiLabel ~" - " ~siteObjects[order.sourceSite].name }}">
                                             <div class="label" data-id="{{ element.id }}" data-editable="" data-site-id={{ order.sourceSite }} {% if entryPreviewSettings["draftId"] is defined %} data-draft-id="{{ entryPreviewSettings["draftId"] }}" {% endif %}>
                                                 <span class="title text-link">{{ element.uiLabel }}</span>
                                             </div>

--- a/src/templates/_components/_forms/order-files-table.twig
+++ b/src/templates/_components/_forms/order-files-table.twig
@@ -60,7 +60,7 @@
                         {% else %}
                             <div id="{{ "filePreview-"~ file.id }}">
                                 <div class="elements">
-                                    <div class="element small" title="{{ file.uiLabel ~" - " ~siteObjects[file.targetSite].name }}">
+                                    <div class="element flex" title="{{ file.uiLabel ~" - " ~siteObjects[file.targetSite].name }}">
                                         <div class="label" data-id="{{ file.elementId }}" data-editable="" data-site-id={{ file.targetSite }} {% if file.isComplete or element.isDraft %} data-draft-id={{ file.isComplete ? file.draftId : element.draftId }} {% endif %}>
                                             <span class="title text-link">{{ file.uiLabel }}</span>
                                         </div>

--- a/src/templates/_components/app-info.twig
+++ b/src/templates/_components/app-info.twig
@@ -1,4 +1,5 @@
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
+{% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set emailSubject = 'Hello Acclaro' %}
 {% set emailBody = 'I’m interested in learning more about your professional translation services and how you can help with the launch of global Craft sites.%0D%0A%0D%0AThank you,%0D%0AYour Name%0D%0AYour Company%0D%0AYour Phone Number' %}

--- a/src/templates/_components/orders/settings-tab.twig
+++ b/src/templates/_components/orders/settings-tab.twig
@@ -121,6 +121,27 @@
 			</div>
 
 			<input type="hidden" id="originalTrackTargetChanges" value="{{ order.trackTargetChanges }}">
+			
+			{% set preventSlugTranslationClass = "" %}
+			{% set preventSlugTranslationTitle = "" %}
+			{% if not order.isPending %}
+				{% set preventSlugTranslationClass = "non-editable disabled" %}
+				{% set preventSlugTranslationTitle = "This field cannot be edited." %}
+			{% endif %}
+			<span class="{{ preventSlugTranslationClass }}">
+				<div style="margin-bottom: 10px" class="{% if preventSlugTranslationClass %} noClick {% endif %}" title="{{ preventSlugTranslationTitle }}">
+					{{ forms.lightswitchField({
+						label: 'Prevent Slug Translation<p class="fw-400">\
+						Prevent\'s the translation of slug fields for the entries in this order.</p>'|t('app'),
+						id: "preventSlugTranslation",
+						name: "preventSlugTranslation",
+						class: "noClick",
+						on: order.preventSlugTranslation
+				}) }}
+				</div>
+			</span>
+
+			<input type="hidden" id="originalPreventSlugTranslation" value="{{ order.preventSlugTranslation }}">
 
 			{% set includeTmFilesClass = "" %}
 			{% set includeTmFilesTitle = "" %}
@@ -129,7 +150,7 @@
 				{% set includeTmFilesTitle = "This field cannot be edited." %}
 			{% endif %}
 			<span class="{{ includeTmFilesClass }}">
-				<div style="margin-bottom: 0" class="{% if includeTmFilesClass %} noClick {% endif %}" title="{{ includeTmFilesTitle }}">
+				<div style="margin-bottom: 0px" class="{% if includeTmFilesClass %} noClick {% endif %}" title="{{ includeTmFilesTitle }}">
 					{{ forms.lightswitchField({
 						label: 'Include translation memory alignment files<p class="fw-400">\
 							Include translation memory alignment files with order submission to prevent overwriting existing content edits.</p>'|t('app'),
@@ -217,21 +238,5 @@
 				<input type="hidden" id="tagGroupId" value="{{ tagGroup.id|default('') }}">
 			</div>
 		</div>
-
-		{# {{ forms.lightswitchField({
-			label: 'Asynchronous publishing<p class="fw-400">Creates a seprate translation draft \
-				for each target language that can be published independently.</p>'|t
-				(tag('button', {
-					type: 'button',
-					id: 'expand-status-btn',
-					class: ['btn'],
-					data: {
-						icon: 'ellipsis',
-					},
-				})),
-			id: "asynchronousPublishing",
-			name: "asynchronousPublishing",
-			on: order.asynchronousPublishing
-		}) }} #}
 	</form>
 </div>

--- a/src/templates/_components/orders/settings-tab.twig
+++ b/src/templates/_components/orders/settings-tab.twig
@@ -136,7 +136,7 @@
 						id: "preventSlugTranslation",
 						name: "preventSlugTranslation",
 						class: "noClick",
-						on: order.preventSlugTranslation
+						on: shouldPreventSlugTranslation is defined ? shouldPreventSlugTranslation : order.shouldPreventSlugTranslation
 				}) }}
 				</div>
 			</span>

--- a/src/templates/_index.twig
+++ b/src/templates/_index.twig
@@ -4,7 +4,7 @@
 {% set title = "Translation Dashboard"|t %}
 {% set elementType = 'acclaro\\translations\\elements\\Order' %}
 {% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus(pluginHandle) %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set updates = craft.app.getApi().getUpdates().plugins.translations %}
 

--- a/src/templates/settings/about.twig
+++ b/src/templates/settings/about.twig
@@ -20,9 +20,6 @@
 
         <h4 style="margin-top: 0px;">{{ 'by Acclaro Inc.'|t }}</h4>
 
-        {% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
-        {% set baseAssetsUrl = craft.app.assetManager.getPublishedUrl('@acclaro/translations/assetbundles/src', true ) %}
-
         <div>
             <h3>{{ 'General Information'|t }}</h3>
             <p>This plugin is made available by <a href="https://www.acclaro.com/">Acclaro</a>. Any usage of it on a public site requires that the site owners have purchased the plugin either from Acclaro or the Craft plugin store.</p>

--- a/src/templates/settings/configuration-options.twig
+++ b/src/templates/settings/configuration-options.twig
@@ -29,6 +29,7 @@
                 'chkDuplicateEntries': chkDuplicateEntries,
                 'trackSourceChanges': trackSourceChanges,
                 'trackTargetChanges': trackTargetChanges,
+                'preventSlugTranslation': preventSlugTranslation,
                 'apiLogging': apiLogging,
             },
         }) }}
@@ -58,6 +59,14 @@
             id: 'trackTargetChanges',
             name: 'trackTargetChanges',
             on: trackTargetChanges,
+        }) }}
+
+        {{ forms.lightswitchField({
+            label: "Prevent slug translations by default"|t('app'),
+            instructions: "Enables the \"Prevent slug translations\" settings by default on new submission."|t('app'),
+            id: 'preventSlugTranslation',
+            name: 'preventSlugTranslation',
+            on: preventSlugTranslation,
         }) }}
 
         <hr>
@@ -128,7 +137,7 @@
 
 {% js %}
     $( document ).ready(function() {
-        $('#chkDuplicateEntries, #apiLogging, #trackSourceChanges, #trackTargetChanges').change(function() {
+        $('#chkDuplicateEntries, #preventSlugTranslation, #apiLogging, #trackSourceChanges, #trackTargetChanges').change(function() {
             if (isChanged()) {
                 $('#save-configuration').addClass('submit');
             } else {


### PR DESCRIPTION
## Pull Request

### Description:
Release 3.2.6

### Related Issue(s):
[#437] Paid version still shows `Free Trial`
[#439 ] Asset translation issue

### Changes Made:
Provided additional prevent slug translations light switch to skip slug field in translation source files if user wish not to translate slug of entries in a particular order, by default the slug will be translated.

**Added:**
- Prevent slug field light switch in advance section of order details page.
- Global setting to keep slug translation setting persistent as default for all orders.

**Changed:**

- `craft.app.plugins.getPluginLicenseKeyStatus()` with `craft.app.plugins.getPluginInfo()` to check license status.

**Fixed:**

- An issue where asset title was included in translation source file regardless of if the field is translatable or not.


### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- Testing complete and found no issue impacting the performance.

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/eaaba535-c83e-4954-a453-40d9e408f090)
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/800481f8-2958-46cd-a832-d6e825d70a77)

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


