### PR TITLE
Release/2.2.5

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "2.2.4",
+    "pluginVersion": "2.2.5",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.2.5 - 2023-05-23
+## 2.2.5 - 2023-05-29
 
 ### Fixed
 - An issue where plugin license was always showing `free trial` despite of `Paid` even after license is purchased. ([AcclaroInc#437](https://github.com/AcclaroInc/craft-translations/issues/437))
+- An issue where asset's title was incuded in source files regardless of translation enabled or not. ([AcclaroInc#439](https://github.com/AcclaroInc/craft-translations/issues/439)]
 
 ## 2.2.4 - 2023-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.5 - 2023-05-23
+
+### Fixed
+- An issue where plugin license was always showing `free trial` despite of `Paid` even after license is purchased. ([AcclaroInc#437](https://github.com/AcclaroInc/craft-translations/issues/437))
+
 ## 2.2.4 - 2023-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 - An issue where plugin license was always showing `free trial` despite of `Paid` even after license is purchased. ([AcclaroInc#437](https://github.com/AcclaroInc/craft-translations/issues/437))
-- An issue where asset's title was incuded in source files regardless of translation enabled or not. ([AcclaroInc#439](https://github.com/AcclaroInc/craft-translations/issues/439)]
+- An issue where asset's title was incuded in source files regardless of translation enabled or not. ([AcclaroInc#439](https://github.com/AcclaroInc/craft-translations/issues/439))
 
 ## 2.2.4 - 2023-02-06
 

--- a/src/services/fieldtranslator/AssetsFieldTranslator.php
+++ b/src/services/fieldtranslator/AssetsFieldTranslator.php
@@ -29,9 +29,10 @@ class AssetsFieldTranslator extends GenericFieldTranslator
         {
             foreach ($blocks as $block)
             {
-                $source[sprintf('%s.%s.%s', $field->handle, $block->id, 'title')] = $block->title;
-
                 $element = Craft::$app->assets->getAssetById($block->id, $sourceSite);
+                if ($element->getIsTitleTranslatable()) {
+                    $source[sprintf('%s.%s.%s', $field->handle, $block->id, 'title')] = $block->title;
+                }
                 foreach ($element->getFieldLayout()->getFields() as $layoutField) {
                     $assetField = Craft::$app->fields->getFieldById($layoutField->id);
                     $fieldSource = $elementTranslator->fieldToTranslationSource($element, $assetField, $sourceSite);

--- a/src/templates/_components/app-info.twig
+++ b/src/templates/_components/app-info.twig
@@ -1,4 +1,5 @@
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
+{% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set emailSubject = 'Hello Acclaro' %}
 {% set emailBody = 'I’m interested in learning more about your professional translation services and how you can help with the launch of global Craft sites.%0D%0A%0D%0AThank you,%0D%0AYour Name%0D%0AYour Company%0D%0AYour Phone Number' %}

--- a/src/templates/_index.twig
+++ b/src/templates/_index.twig
@@ -4,7 +4,7 @@
 {% set title = "Translation Dashboard"|t %}
 {% set elementType = 'acclaro\\translations\\elements\\Order' %}
 {% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus(pluginHandle) %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set updates = craft.app.getApi().getUpdates().plugins.translations %}
 

--- a/src/templates/settings/about.twig
+++ b/src/templates/settings/about.twig
@@ -20,9 +20,6 @@
 
         <h4 style="margin-top: 0px;">{{ 'by Acclaro Inc.'|t }}</h4>
 
-        {% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
-        {% set baseAssetsUrl = craft.app.assetManager.getPublishedUrl('@acclaro/translations/assetbundles/src', true ) %}
-
         <div>
             <h3>{{ 'General Information'|t }}</h3>
             <p>This plugin is made available by <a href="https://www.acclaro.com/">Acclaro</a>. Any usage of it on a public site requires that the site owners have purchased the plugin either from Acclaro or the Craft plugin store.</p>


### PR DESCRIPTION
## Pull Request

### Description:
Plugin license was chowing as free trial even if user adds a paid license.

### Related Issue(s):
[#437] Paid version still shows `Free Trial`
[#439 ] Asset translation issue

### Changes Made:

**Changed:**

- `craft.app.plugins.getPluginLicenseKeyStatus()` with `craft.app.plugins.getPluginInfo()` to check license status.

**Removed:**

- Unused code from `About` template.

**Fixed:**

- An issue where asset title was included in translation source file regardless of if the field is translatable or not.

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- Testing complete and found no issue impacting the performance.

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/7fafe28f-6867-41f0-9188-7893e996a13d)


### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


