### PR TITLE
fixed: plugin license status issue

### DIFF
--- a/src/templates/_components/app-info.twig
+++ b/src/templates/_components/app-info.twig
@@ -1,4 +1,5 @@
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
+{% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set emailSubject = 'Hello Acclaro' %}
 {% set emailBody = 'I’m interested in learning more about your professional translation services and how you can help with the launch of global Craft sites.%0D%0A%0D%0AThank you,%0D%0AYour Name%0D%0AYour Company%0D%0AYour Phone Number' %}

--- a/src/templates/_index.twig
+++ b/src/templates/_index.twig
@@ -4,7 +4,7 @@
 {% set title = "Translation Dashboard"|t %}
 {% set elementType = 'acclaro\\translations\\elements\\Order' %}
 {% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
-{% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus(pluginHandle) %}
+{% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
 {% set updates = craft.app.getApi().getUpdates().plugins.translations %}
 

--- a/src/templates/settings/about.twig
+++ b/src/templates/settings/about.twig
@@ -20,9 +20,6 @@
 
         <h4 style="margin-top: 0px;">{{ 'by Acclaro Inc.'|t }}</h4>
 
-        {% set licenseStatus = craft.app.plugins.getPluginLicenseKeyStatus('translations') %}
-        {% set baseAssetsUrl = craft.app.assetManager.getPublishedUrl('@acclaro/translations/assetbundles/src', true ) %}
-
         <div>
             <h3>{{ 'General Information'|t }}</h3>
             <p>This plugin is made available by <a href="https://www.acclaro.com/">Acclaro</a>. Any usage of it on a public site requires that the site owners have purchased the plugin either from Acclaro or the Craft plugin store.</p>


### PR DESCRIPTION
## Pull Request

### Description:
Plugin license was chowing as free trial even if user adds a paid license.

### Related Issue(s):
[#437] Paid version still shows `Free Trial`


### Changes Made:

**Added:**

- 

**Changed:**

- `craft.app.plugins.getPluginLicenseKeyStatus()` with `craft.app.plugins.getPluginInfo()` to check license status.

**Deprecated:**

-

**Removed:**

- Unused code from `About` template.

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/7fafe28f-6867-41f0-9188-7893e996a13d)


### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]
