### PR TITLE
Bug/543/super table fields duplicated on merge and apply

### DIFF
--- a/src/services/repository/EntryRepository.php
+++ b/src/services/repository/EntryRepository.php
@@ -34,14 +34,21 @@ class EntryRepository extends Component
                 ->admin()
                 ->orderBy(['elements.id' => SORT_ASC])
                 ->one();
-            $elementURI = Craft::$app->getElements()->getElementUriForSite($entry->id, $site);
+            // $elementURI = Craft::$app->getElements()->getElementUriForSite($entry->id, $site);
 
+            // Commented to fix supertable field duplication issue
             $newAttributes = [
-                'siteId' => $site,
-                'uri' => $elementURI,
+                // 'siteId' => $site,
+                // 'uri' => $elementURI,
             ];
 
             $draft = $this->makeNewDraft($entry, $creator->id, $name, $notes, $newAttributes);
+            
+            $draft->siteId = $site;
+            if (!Craft::$app->getElements()->saveElement($draft)) {
+                throw new \Exception("Failed to save draft in target site");
+            }
+            $draft = Craft::$app->getElements()->propagateElement($draft, $site);
 
             return $draft;
         } catch (\Exception $e) {

--- a/src/services/repository/EntryRepository.php
+++ b/src/services/repository/EntryRepository.php
@@ -69,10 +69,12 @@ class EntryRepository extends Component
 
 		$transaction = Craft::$app->getDb()->beginTransaction();
         try {
+            $targetSiteId = $newAttributes['siteId'];
+            $enabledForSites = Craft::$app->getElements()->getEnabledSiteIdsForElement($canonical->id);
+            $isNewForSite = !in_array($targetSiteId, $enabledForSites);
+
             // Create the draft row
             $draftId = (new Drafts())->insertDraftRow($name, $notes, $creatorId, $canonical->id, $canonical::trackChanges(), $provisional);
-            $targetSiteId = $newAttributes['siteId'];
-            unset($newAttributes['siteId']);
             // Duplicate the element
             $newAttributes['isProvisionalDraft'] = $provisional;
             $newAttributes['canonicalId'] = $canonical->id;
@@ -85,13 +87,19 @@ class EntryRepository extends Component
                 'trackChanges' => $canonical::trackChanges(),
             ];
 
+            if ($isNewForSite) {
+                unset($newAttributes['siteId']);
+            }
             $draft = Craft::$app->getElements()->duplicateElement($canonical, $newAttributes);
 
-            $draft->siteId = $targetSiteId;
-            if (!Craft::$app->getElements()->saveElement($draft)) {
-                throw new \Exception("Failed to save draft in target site");
+            if ($isNewForSite) {
+                // We can only set the target site it it does not exist else craft erros out.
+                $draft->siteId = $targetSiteId;
+                if (!Craft::$app->getElements()->saveElement($draft)) {
+                    throw new \Exception("Failed to save draft in target site");
+                }
+                $draft = Craft::$app->getElements()->propagateElement($draft, $targetSiteId);
             }
-            $draft = Craft::$app->getElements()->propagateElement($draft, $targetSiteId);
 
             $transaction->commit();
         } catch (\Throwable $e) {

--- a/src/services/repository/EntryRepository.php
+++ b/src/services/repository/EntryRepository.php
@@ -36,14 +36,12 @@ class EntryRepository extends Component
                 ->one();
             $elementURI = Craft::$app->getElements()->getElementUriForSite($entry->id, $site);
 
-            // Commented to fix supertable field duplication issue
             $newAttributes = [
                 'siteId' => $site,
                 'uri' => $elementURI,
             ];
 
             $draft = $this->makeNewDraft($entry, $creator->id, $name, $notes, $newAttributes);
-
 
             return $draft;
         } catch (\Exception $e) {

--- a/src/services/repository/EntryRepository.php
+++ b/src/services/repository/EntryRepository.php
@@ -73,6 +73,7 @@ class EntryRepository extends Component
 
             // Create the draft row
             $draftId = (new Drafts())->insertDraftRow($name, $notes, $creatorId, $canonical->id, $canonical::trackChanges(), $provisional);
+
             // Duplicate the element
             $newAttributes['isProvisionalDraft'] = $provisional;
             $newAttributes['canonicalId'] = $canonical->id;


### PR DESCRIPTION
## Pull Request

### Description:
Fixed an issue where entry with super-table fields duplicated the blocks on merge and apply.

### Related Issue(s):

- #453

### Changes Made:

**Added:**

- 

**Changed:**

- The logic for draft creation to work differently if the target site is not yet enabled for entry for which the draft is created.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


