### PR TITLE
Release 3.2.9

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "3.2.8",
+    "pluginVersion": "3.2.9",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.9 - 2023-07-26
+
+### Fixed
+- An issue where log files were flooded with warning. ([AcclaroInc#456](https://github.com/AcclaroInc/craft-translations/issues/456))
+
+### Chore
+- Code refactoring and cleanup.
+
 ## 3.2.8 - 2023-07-03
 
 ### Fixed

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -86,25 +86,8 @@ class Translations extends Plugin
         Event::on(
             Plugins::class,
             Plugins::EVENT_AFTER_LOAD_PLUGINS,
-            function () {
-                if (self::getInstance()->settings->apiLogging) {
-                    Craft::debug(
-                        '['. __METHOD__ .'] Plugins::EVENT_AFTER_LOAD_PLUGINS',
-                        'translations'
-                    );
-                }
-                $this->setComponents([
-                    'app' => App::class
-                ]);
-
-                self::$plugin = $this->get('app');
-                self::$view = Craft::$app->getView();
-
-                $this->installEventListeners();
-
-                if (Craft::$app instanceof ConsoleApplication) {
-                    $this->controllerNamespace = 'acclaro\translations\console\controllers';
-                }
+            function() { 
+                $this->registerAfterLoadEvents();
             }
         );
 
@@ -337,6 +320,33 @@ class Translations extends Plugin
                 $this->installCpEventListeners();
             }
         }
+    }
+
+    // Wait for craft to complete init after which load plugin
+    private function registerAfterLoadEvents(): void {
+        $actions = function () {
+            if (self::getInstance()->settings->apiLogging) {
+                Craft::debug(
+                    '[' . __METHOD__ . '] Plugins::EVENT_AFTER_LOAD_PLUGINS',
+                    'translations'
+                );
+            }
+            $this->setComponents([
+                'app' => App::class
+            ]);
+
+            self::$plugin = $this->get('app');
+            self::$view = Craft::$app->getView();
+
+            $this->installEventListeners();
+
+            if (Craft::$app instanceof ConsoleApplication) {
+                $this->controllerNamespace = 'acclaro\translations\console\controllers';
+            }
+        };
+
+        // Start initialisation after craft has been initialized
+        Craft::$app->onInit($actions);
     }
 
     private function _registerCpRoutes()

--- a/src/assetbundles/src/js/OrderDetails.js
+++ b/src/assetbundles/src/js/OrderDetails.js
@@ -884,8 +884,13 @@
                 setUnloadEvent(false);
                 if ($(that).text() == "Create new order") {
                     var url = window.location.origin+"/admin/translations/orders/create";
-                    $form.find("input[type=hidden][name=action]").val('translations/order/clone-order');
+                    $form.find("input[type=hidden][name=action]").val('translations/order/order-detail');
                     window.history.pushState("", "", url);
+                    $('<input>', {
+                        'type': 'hidden',
+                        'name': 'clone',
+                        'value': 1
+                    }).appendTo($form);
                     $form.submit();
                 }else if ($(that).text() == "Update order") {
                     var postData = Garnish.getPostData($form),
@@ -932,10 +937,15 @@
                 var $hiddenAction = $('<input>', {
                     'type': 'hidden',
                     'name': 'action',
-                    'value': 'translations/order/save-order-draft'
+                    'value': 'translations/order/save-order'
                 });
 
                 $hiddenAction.appendTo($form);
+                $('<input>', {
+                    'type': 'hidden',
+                    'name': 'createDraft',
+                    'value': '1',
+                }).appendTo($form);
 
                 $form.submit();
             });

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -16,7 +16,6 @@ use craft\elements\Entry;
 use acclaro\translations\Constants;
 use acclaro\translations\Translations;
 use acclaro\translations\base\AlertsTrait;
-use acclaro\translations\services\Services;
 use acclaro\translations\services\job\RegeneratePreviewUrls;
 
 /**

--- a/src/controllers/CommerceController.php
+++ b/src/controllers/CommerceController.php
@@ -25,7 +25,6 @@ use yii\web\Response;
 use acclaro\translations\Constants;
 use acclaro\translations\Translations;
 use craft\helpers\Json;
-use craft\helpers\UrlHelper;
 
 /**
  * Class CommerceController will be used to process Craft Commerce Products/Variants

--- a/src/controllers/WidgetController.php
+++ b/src/controllers/WidgetController.php
@@ -174,14 +174,18 @@ class WidgetController extends BaseController
     {
         $hasUpdate = false;
 
-        $updateData = Craft::$app->getApi()->getUpdates([]);
-
-        $updates = new UpdatesModel($updateData);
-
-        foreach ($updates->plugins as $key => $pluginUpdate) {
-            if ($key === $pluginHandle && $pluginUpdate->getHasReleases()) {
-                $hasUpdate = true;
+        try {
+            $updateData = Craft::$app->getApi()->getUpdates([]);
+    
+            $updates = new UpdatesModel($updateData);
+    
+            foreach ($updates->plugins as $key => $pluginUpdate) {
+                if ($key === $pluginHandle && $pluginUpdate->getHasReleases()) {
+                    $hasUpdate = true;
+                }
             }
+        }catch(\Exception $e) {
+            Translations::$plugin->logHelper->log($e->getMessage(), Constants::LOG_LEVEL_ERROR);
         }
 
         return $hasUpdate;

--- a/src/templates/_index.twig
+++ b/src/templates/_index.twig
@@ -6,7 +6,6 @@
 {% set pluginHandle = constant('acclaro\\translations\\Constants::PLUGIN_HANDLE') %}
 {% set licenseStatus = craft.app.plugins.getPluginInfo(pluginHandle)['licenseKeyStatus']|default(null) %}
 {% set edition = (licenseStatus == 'valid') ? 'Paid' : 'Free trial' %}
-{% set updates = craft.app.getApi().getUpdates().plugins.translations %}
 
 {% block toolbar %}
     <div id="edition-logo" title="Translations ({{ edition }})" aria-label="Translations ({{ edition }})" style="margin: 7px 0px 10px 15px;">


### PR DESCRIPTION
## Pull Request

### Description:
This PR includes a bug where log files were flooded by element query executed before craft is fully initialised along with some code refactors to reduce some extra actions in order controller.

### Related Issue(s):
- #456 


### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- A check before registering after plugin load events for if the craft is initialised.

**Changed:**

-

**Deprecated:**

-

**Removed:**

- Clone order controller action that is to be done by using Save order action.

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


