### PR TITLE
fixed: error shown in dev mode when a new update is available

### DIFF
--- a/src/templates/_index.twig
+++ b/src/templates/_index.twig
@@ -12,7 +12,7 @@
         <div class="edition-name">{{ edition }}</div>
         <div class="edition-trial">{{ craft.app.getPlugins().getPlugin(pluginHandle).getVersion() }}</div>
     </div>
-    {% if updates and updates.releases %}
+    {% if updates %}
         <a class="btn small go" href="utilities/updates" data-icon="info" style="margin: 7px 0px 10px 0px;"> Update available</a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Pull Request

### Description:
A twig error was shown when the dashboard is opened with craft running in dev mode and a new update of plugin is available.

### Related Issue(s):
- #461 

### Changes Made:
The update variable obtained as a response from craft update api used to be an object as the old code tries to check a key `releases` and now it's a boolean value so removed that check to prevent error.

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

- The `updates.release` from logic as updates now is a boolean value. 

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- Test to check we don't see an error page when an update is available and the dev mode is enabled for craft setup.

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/afe31bb3-356c-4511-b2ff-e760d7da60bc)

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


