### PR TITLE
fixed: draft not created when entry is disabled in target site

### DIFF
--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -253,18 +253,22 @@ class DraftRepository
     {
 		$element = $element->getIsDraft() ? $element->getCanonical() : $element;
 
-        switch (get_class($element)) {
-            case Product::class:
-                $draft = Translations::$plugin->commerceRepository->createDraft($element, $site, $order->title);
-                break;
-            case GlobalSet::class:
-                $draft = Translations::$plugin->globalSetDraftRepository->createDraft($element, $site, $order->title);
-                break;
-            case Asset::class:
-                $draft = Translations::$plugin->assetDraftRepository->createDraft($element, $site, $order->title, $order->sourceSite);
-                break;
-            default:
-                $draft = Translations::$plugin->entryRepository->createDraft($element, $site, $order->title);
+        try {
+            switch (get_class($element)) {
+                case Product::class:
+                    $draft = Translations::$plugin->commerceRepository->createDraft($element, $site, $order->title);
+                    break;
+                case GlobalSet::class:
+                    $draft = Translations::$plugin->globalSetDraftRepository->createDraft($element, $site, $order->title);
+                    break;
+                case Asset::class:
+                    $draft = Translations::$plugin->assetDraftRepository->createDraft($element, $site, $order->title, $order->sourceSite);
+                    break;
+                default:
+                    $draft = Translations::$plugin->entryRepository->createDraft($element, $site, $order->title);
+            }
+        } catch(Exception $e) {
+            throw $e;
         }
 
         if (!($file instanceof FileModel)) {
@@ -273,7 +277,7 @@ class DraftRepository
 
         if (empty($draft)) {
             Translations::$plugin->logHelper->log(  '['. __METHOD__ .'] Empty draft found: Order'.json_decode($order), Constants::LOG_LEVEL_ERROR );
-            return false;
+            throw new \Exception("Unable to create draft.");
         }
 
         if (!$file->hasPreview()) {
@@ -302,7 +306,7 @@ class DraftRepository
 
             Translations::$plugin->fileRepository->saveFile($file);
 
-            return false;
+            throw $e;
         }
     }
 


### PR DESCRIPTION
## Pull Request

### Description:
Drafts were not getting created for entries that are disabled for target site and showing success message to user.

### Related Issue(s):

- #463 

### Changes Made:
Ensured create draft does not show success when it fails and also fixed issue preventing draft creation for disabled target entry.

**Added:**

- A try catch block when creating draft to capture the exact issue and show error in case if any.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

- An issue where draft for a disabled entry in target site was not created.

**Security:**

-

### Testing:

- Test by creating an order and complete round trip for an entry which is disabled in target site.

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


