### PR TITLE
fixed: error opening static translation page after craft 4.5.0

### DIFF
--- a/src/services/repository/StaticTranslationsRepository.php
+++ b/src/services/repository/StaticTranslationsRepository.php
@@ -88,7 +88,7 @@ class StaticTranslationsRepository
                         $translateId = ElementHelper::normalizeSlug($original);
                         $view = Craft::$app->getView();
                         $site = Craft::$app->getSites()->getSiteById($query->siteId);
-                        $translation = Craft::t($category, $original, null, $site->language);
+                        $translation = Craft::t($category, $original, [], $site->language);
 
                         $field = $view->renderTemplate('_includes/forms/text', [
                             'id' => $translateId,


### PR DESCRIPTION
## Pull Request

### Description:
Fixed an error where static translation page was showing error after craft 4.5.0 upgrade.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- #468 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

- A param to `Craft::t()` which actually needs to be an empty array in place of null.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [x] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [x] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


