### PR TITLE
Feature/512/sync order files on order callback trigger

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -81,6 +81,8 @@ class BaseController extends Controller
             Craft::$app->end('Invalid orderId');
         } else {
             echo 'Order found'.PHP_EOL;
+            $order->logActivity('Order callback received.');
+            Craft::$app->getElements()->saveElement($order);
         }
 
         // don't process published orders
@@ -163,6 +165,8 @@ class BaseController extends Controller
             Craft::$app->end('Couldn’t find the order');
         } else {
             echo 'Found order'.PHP_EOL;
+            $order->logActivity('File callback received.');
+            Craft::$app->getElements()->saveElement($order);
         }
 
         $translationService = $order->getTranslationService();

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -117,6 +117,7 @@ class BaseController extends Controller
 
             foreach($order->getFiles() as $file) {
                 $translationService->updateFile($order, $file);
+                Translations::$plugin->fileRepository->saveFile($file);
             }
 
             echo 'File sync successful' . PHP_EOL;

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -110,7 +110,14 @@ class BaseController extends Controller
         if (!$success) {
             Craft::$app->end('Couldn’t save the order');
         } else {
-            echo 'Saving order'.PHP_EOL;
+            echo 'Order changes saved'.PHP_EOL;
+            echo 'Starting file sync' . PHP_EOL;
+
+            foreach($order->getFiles() as $file) {
+                $translationService->updateFile($order, $file);
+            }
+
+            echo 'File sync successful' . PHP_EOL;
         }
 
         Craft::$app->end('OK');


### PR DESCRIPTION
## Pull Request

### Description:
The file updates were not getting delivered via callbacks. As asked we included file sync login within order callback action similar to what is done in contentful connector.

### Related Issue(s):

- [Round trip is not working](https://github.com/AcclaroInc/pm-craft-translations/issues/512)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- File sync logic with in order callback action.
- Order activity log on order/file callback receiving.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- Can be tested by a round trip where files are completed on acclaro and same should sync automatically to craft in some cool down time.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
![image](https://github.com/AcclaroInc/craft-translations/assets/72725957/77134e09-88c1-4f85-9fe3-b39a69bc9c18)

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


