### PR TITLE
fixed: an issue where uploaded assets saving to temp directory only

### DIFF
--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -230,7 +230,8 @@ class FilesController extends BaseController
 
                                 $fileInfo = pathinfo($filename);
 
-                                $folder = Craft::$app->getAssets()->getUserTemporaryUploadFolder();
+                                $uploadVolumeId = ArrayHelper::getValue(Translations::getInstance()->getSettings(), 'uploadVolume');
+                                $folder = $this->getFolderByVolumeId($uploadVolumeId);
 
                                 $pathInfo = pathinfo($file);
 
@@ -311,7 +312,8 @@ class FilesController extends BaseController
                     } else {
                         $filename = Assets::prepareAssetName($file->name);
 
-                        $folder = Craft::$app->getAssets()->getUserTemporaryUploadFolder();
+                        $uploadVolumeId = ArrayHelper::getValue(Translations::getInstance()->getSettings(), 'uploadVolume');
+                        $folder = $this->getFolderByVolumeId($uploadVolumeId);
 
                         $compatibleFilename = $file->tempName . '.' . Constants::FILE_FORMAT_TXT;
 
@@ -575,5 +577,13 @@ class FilesController extends BaseController
         $zip_name =  $title.'_'.$order['id'];
 
         return $zip_name;
+    }
+    
+    private function getFolderByVolumeId($volumeId) {
+        if ($volumeId == 0) {
+            return Craft::$app->getAssets()->getUserTemporaryUploadFolder();
+        } else {
+            return Craft::$app->getAssets()->getRootFolderByVolumeId($volumeId);
+        }
     }
 }


### PR DESCRIPTION
## Pull Request

### Description:
As we made a fix to error that arise after craft 4.5.0 update in which uploading delivery files was showing error, so we used crafts temp location for it due to which all asset uploads were sent to temp directory irrespective of what volume we select from plugins settings page. Now here we corrected the issue to use the volume if its not 0 and use temp location otherwise.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


