### PR TITLE
Bug/475/error when plugin tag group is deleted by user

### DIFF
--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -99,7 +99,7 @@ class OrderController extends BaseController
 		$variables['chkDuplicateEntries'] = Translations::getInstance()->settings->chkDuplicateEntries;
         $variables['tagGroup'] = Craft::$app->getTags()->getTagGroupByHandle(Constants::ORDER_TAG_GROUP_HANDLE);
 
-        // In case for some reason tag group is not present we will create one.
+        // In case for some reason tag group is not present or deleted by user we will create one.
         if (!$variables['tagGroup']) {
             $tagGroup = new \craft\models\TagGroup();
             $tagGroup->name = 'Craft Translations';

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -98,6 +98,17 @@ class OrderController extends BaseController
 		$variables['orientation'] = Craft::$app->getLocale()->orientation;
 		$variables['chkDuplicateEntries'] = Translations::getInstance()->settings->chkDuplicateEntries;
         $variables['tagGroup'] = Craft::$app->getTags()->getTagGroupByHandle(Constants::ORDER_TAG_GROUP_HANDLE);
+
+        // In case for some reason tag group is not present we will create one.
+        if (!$variables['tagGroup']) {
+            $tagGroup = new \craft\models\TagGroup();
+            $tagGroup->name = 'Craft Translations';
+            $tagGroup->handle = Constants::ORDER_TAG_GROUP_HANDLE;
+
+            Craft::$app->getTags()->saveTagGroup($tagGroup);
+            $variables['tagGroup'] = Craft::$app->getTags()->getTagGroupByHandle(Constants::ORDER_TAG_GROUP_HANDLE);
+        }
+
         $variables['apiLogging'] =  Translations::getInstance()->settings->apiLogging;
 
         $variables['versionsByElementId'] = [];


### PR DESCRIPTION
## Pull Request

### Description:
An error is shown in case the plugins default tag group is somehow deleted from craft.

### Related Issue(s):

- #475 

### Changes Made:

**Added:**

- logic to create tag group in case it is not found when loading order details page.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [x] The changes have been tested on different environments (e.g., staging, production).
- [x] Integration tests have been performed to verify the interactions between components.
- [x] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


