### PR TITLE
fixed: comments failing on acclaro issue

### DIFF
--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -311,6 +311,10 @@ class OrderRepository
                 $translationService->addOrderTags($orderResponse->orderid, implode(",", $tags));
             }
         }
+        
+        if ($comments) {
+            $translationService->addOrderComments($orderResponse->orderid, $comments);
+        }
 
         $orderReferenceFiles = [];
 

--- a/src/services/translator/AcclaroTranslationService.php
+++ b/src/services/translator/AcclaroTranslationService.php
@@ -444,6 +444,11 @@ class AcclaroTranslationService implements TranslationServiceInterface
     {
         return $this->apiClient->addOrderTags($orderId, $tags);
     }
+    
+    public function addOrderComments($orderId, $comment)
+    {
+        return $this->apiClient->addOrderComment($orderId, $comment);
+    }
 
     public function getOrderQuote($orderId)
     {


### PR DESCRIPTION
## Pull Request

### Description:
The comment added to craft order on creation is not reflected on my acclaro's order comments tab.

### Related Issue(s):

- [Comments failing](https://github.com/AcclaroInc/pm-craft-translations/issues/516)

### Changes Made:

**Added:**

- Added a new function to process order comments to acclaro.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Create a fresh order from craft cms to acclaro with some comment and see that comment on my acclaro order details page's comments section.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


