### PR TITLE
Fix failing migration if `activitylog` table is empty

### DIFF
--- a/src/migrations/m240117_112821_create_activity_logs_table.php
+++ b/src/migrations/m240117_112821_create_activity_logs_table.php
@@ -32,7 +32,7 @@ class m240117_112821_create_activity_logs_table extends Migration
         $data = $this->db->createCommand('SELECT "id", "activityLog" FROM {{%translations_orders}}')->queryAll();
 
         foreach ($data as $row) {
-            $messages = json_decode($row['activityLog'], true);
+            $messages = json_decode($row['activityLog'], true) ?: [];
 
             foreach ($messages as $message) {
                 // Insert data into activity_log table


### PR DESCRIPTION
```
*** applying m240117_112821_create_activity_logs_table
> create table {{%translations_activitylogs}} ... done (time: 0.121s)
> create index craft_idx_skbcykktosmeitobyjtmlufiryicduasxyck on {{%translations_activitylogs}} (targetId) ... done (time: 0.101s)
> create index craft_idx_vtzmdkqbtenjbxzizjuramanfhqmsmftejxu on {{%translations_activitylogs}} (targetClass) ... done (time: 0.050s)               Exception: foreach() argument must be of type array|object, null given (/app/vendor/acclaro/translations/src/migrations/m240117_112821_create_activity_logs_table.php:37)
```