### PR TITLE
fixed: order search bar issue

### DIFF
--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -153,7 +153,7 @@ class FilesController extends BaseController
             return $this->asFailure($this->getErrorMessage(implode('\n', $errors)));
         }
 
-        Craft::$app->getElements()->saveElement($order, true, true, false);
+        Craft::$app->getElements()->saveElement($order, true, true, true);
         $transaction->commit();
 
         return $this->asSuccess(null, ['translatedFiles' => $zipDest]);

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -547,7 +547,7 @@ class OrderController extends BaseController
             $order->wordCount = array_sum($wordCounts);
 
             // Manual Translation will make orders 'in progress' status after creation
-            $success = Craft::$app->getElements()->saveElement($order, true, true, false);
+            $success = Craft::$app->getElements()->saveElement($order, true, true, true);
 
             if (!$success) {
                 Translations::$plugin->logHelper->log('[' . __METHOD__ . '] Couldn’t save the order', Constants::LOG_LEVEL_ERROR);
@@ -617,7 +617,7 @@ class OrderController extends BaseController
                 $order->status = Constants::ORDER_STATUS_NEW;
                 $order->dateOrdered = new DateTime();
 
-                $success = Craft::$app->getElements()->saveElement($order, true, true, false);
+                $success = Craft::$app->getElements()->saveElement($order, true, true, true);
 
                 if (! $success) {
                     Translations::$plugin->logHelper->log('[' . __METHOD__ . '] Couldn’t save the order', Constants::LOG_LEVEL_ERROR);

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -163,7 +163,7 @@ class DraftRepository
             $canonical = $draft->getCanonical();
             $draft->setFieldValues($canonical->getFieldValues());
             // Let's try saving the element prior to applying draft
-            if (!Craft::$app->getElements()->saveElement($draft, true, true, false)) {
+            if (!Craft::$app->getElements()->saveElement($draft, true, true, true)) {
                 throw new InvalidElementException($draft);
             }
 


### PR DESCRIPTION
## Pull Request

### Description:
The order search is returning no results when searched for an order using name.

### Related Issue(s):

- [#542](https://github.com/AcclaroInc/pm-craft-translations/issues/542)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


