### PR TITLE
added: existing order re-indexing to migration

### DIFF
--- a/src/controllers/FilesController.php
+++ b/src/controllers/FilesController.php
@@ -153,7 +153,7 @@ class FilesController extends BaseController
             return $this->asFailure($this->getErrorMessage(implode('\n', $errors)));
         }
 
-        Craft::$app->getElements()->saveElement($order, true, true, true);
+        Craft::$app->getElements()->saveElement($order);
         $transaction->commit();
 
         return $this->asSuccess(null, ['translatedFiles' => $zipDest]);

--- a/src/controllers/OrderController.php
+++ b/src/controllers/OrderController.php
@@ -547,7 +547,7 @@ class OrderController extends BaseController
             $order->wordCount = array_sum($wordCounts);
 
             // Manual Translation will make orders 'in progress' status after creation
-            $success = Craft::$app->getElements()->saveElement($order, true, true, true);
+            $success = Craft::$app->getElements()->saveElement($order);
 
             if (!$success) {
                 Translations::$plugin->logHelper->log('[' . __METHOD__ . '] Couldn’t save the order', Constants::LOG_LEVEL_ERROR);
@@ -617,7 +617,7 @@ class OrderController extends BaseController
                 $order->status = Constants::ORDER_STATUS_NEW;
                 $order->dateOrdered = new DateTime();
 
-                $success = Craft::$app->getElements()->saveElement($order, true, true, true);
+                $success = Craft::$app->getElements()->saveElement($order);
 
                 if (! $success) {
                     Translations::$plugin->logHelper->log('[' . __METHOD__ . '] Couldn’t save the order', Constants::LOG_LEVEL_ERROR);
@@ -1185,7 +1185,7 @@ class OrderController extends BaseController
                 }
             }
 
-            Craft::$app->getElements()->saveElement($order, true, true, false);
+            Craft::$app->getElements()->saveElement($order);
             $transaction->commit();
         } catch (\Exception $e) {
             $transaction->rollBack();
@@ -1229,7 +1229,7 @@ class OrderController extends BaseController
 
         $order->status = Constants::ORDER_STATUS_NEW;
         $order->logActivity("Order quote accepted");
-        Craft::$app->getElements()->saveElement($order, true, true, false);
+        Craft::$app->getElements()->saveElement($order);
 
         return $this->asSuccess($this->getSuccessMessage("Quote approve request sent"));
     }
@@ -1266,7 +1266,7 @@ class OrderController extends BaseController
 
         $order->status = Constants::ORDER_STATUS_GETTING_QUOTE;
         $order->logActivity("Order quote declined");
-        Craft::$app->getElements()->saveElement($order, true, true, false);
+        Craft::$app->getElements()->saveElement($order);
 
         return $this->asSuccess($this->getSuccessMessage("Quote decline request sent"));
     }

--- a/src/migrations/m240829_054957_drop_commerce_draft_table.php
+++ b/src/migrations/m240829_054957_drop_commerce_draft_table.php
@@ -2,7 +2,9 @@
 
 namespace acclaro\translations\migrations;
 
+use Craft;
 use craft\db\Migration;
+use acclaro\translations\elements\Order;
 
 /**
  * m240829_054957_drop_commerce_draft_table migration.
@@ -19,6 +21,45 @@ class m240829_054957_drop_commerce_draft_table extends Migration
         $this->dropTableIfExists('{{%translations_commercedrafts}}');
 
         echo "Done dropping translations_commercedrafts table...\n";
+
+        echo "Re-indexing all existing orders...\n";
+
+        $batchSize = 100;
+        $offset = 0;
+        $totalProcessed = 0;
+
+        while (true) {
+            $orders = Order::find()
+                ->limit($batchSize)
+                ->offset($offset)
+                ->all();
+
+            if (empty($orders)) {
+                break;
+            }
+
+            foreach ($orders as $order) {
+                try {
+                    $order = Craft::$app->getElements()->getElementById($order->id, null, $order->sourceSite);
+                    if ($order) {
+                        $order->resaving = true;
+                        if (!Craft::$app->getElements()->saveElement($order)) {
+                            Craft::error('Failed to save order ID: ' . $order->id, __METHOD__);
+                        }
+                    }
+                } catch (\Throwable $e) {
+                    Craft::error('Error re-saving order ID: ' . $order->id . '. Error: ' . $e->getMessage(), __METHOD__);
+                    throw $e;
+                }
+            }
+
+            $totalProcessed += count($orders);
+            $offset += $batchSize;
+
+            echo "Processed $totalProcessed orders so far...\n";
+        }
+
+        echo "Done re-indexing all orders.\n";
 
         return true;
     }

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -163,7 +163,7 @@ class DraftRepository
             $canonical = $draft->getCanonical();
             $draft->setFieldValues($canonical->getFieldValues());
             // Let's try saving the element prior to applying draft
-            if (!Craft::$app->getElements()->saveElement($draft, true, true, true)) {
+            if (!Craft::$app->getElements()->saveElement($draft)) {
                 throw new InvalidElementException($draft);
             }
 


### PR DESCRIPTION
## Pull Request

### Description:
Fixed the indexing issue causing no result when searching for an order from order listing page for old orders.

### Related Issue(s):

-

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- Logic to re index existing orders within the remove commerce draft migration.

**Changed:**

- Removed index flag that prevent indexing when saving orders.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


