### PR TITLE
#9415: edge case for old translators in program selections

### DIFF
--- a/src/controllers/TranslatorController.php
+++ b/src/controllers/TranslatorController.php
@@ -197,7 +197,7 @@ class TranslatorController extends BaseController
         
         $translatorSettings = json_decode($translator->settings, true);
         
-        $addToProgramAllowed = (bool) $translatorSettings['addToProgram'];
+        $addToProgramAllowed = isset($translatorSettings['addToProgram']) ? $translatorSettings['addToProgram'] : false;
         
         $programOptions = [];
         if($addToProgramAllowed) {


### PR DESCRIPTION
## Pull Request

### Related Issue(s):

 - [ ] [#9451](https://github.com/AcclaroInc/acclaro-webapp/issues/9451) 

### Changes Made:

Added a extra check for program option if it is not set

### Testing:

Check for old translators already set up and programs should be enabled and disabled wisely.


### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


