### PR TITLE
fixed: duplicate field handle issue

### DIFF
--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -40,6 +40,7 @@ class ElementTranslator
 
         foreach ($element->getFieldLayout()->getCustomFields() as $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
+            $field->handle = $layoutField->handle;
             $fieldSource = $this->fieldToTranslationSource($element, $field, $sourceSite);
 
             $source = array_merge($source, $fieldSource);
@@ -120,7 +121,6 @@ class ElementTranslator
 
         $contents = $dom->getElementsByTagName('content');
 
-
         foreach ($contents as $content) {
             $name = (string) $content->getAttribute('resname');
             $value = (string) $content->nodeValue;
@@ -163,7 +163,7 @@ class ElementTranslator
 
         foreach($element->getFieldLayout()->getCustomFields() as $key => $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
-            $fieldHandle = $field->handle;
+            $fieldHandle = $field->handle = $layoutField->handle;
 
             $fieldType = $field;
 
@@ -254,6 +254,7 @@ class ElementTranslator
         }
         foreach($element->getFieldLayout()->getCustomFields() as $layoutField) {
             $field = Craft::$app->fields->getFieldById($layoutField->id);
+            $field->handle = $layoutField->handle;
 
             $wordCount += $this->getFieldWordCount($element, $field);
         }


### PR DESCRIPTION
## Pull Request

### Description:
Handled the case when same field is added multiple times in any nested field and the handle is changed by craft cms.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- [Multiple field handles for same field](https://github.com/AcclaroInc/pm-craft-translations/issues/555)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


