### PR TITLE
fixed: handled source entry showing as null

### DIFF
--- a/src/assetbundles/src/js/RecentEntries.js
+++ b/src/assetbundles/src/js/RecentEntries.js
@@ -57,7 +57,8 @@
                                 content.push(item);
 
                                 $container.attr('data-id', item.entryId);
-
+                                
+                                item.entryName = item.entryName || 'Untitled';
                                 var widgetHtml = `
                                 <td id="check-entry-${i}" class="new-entry-check checkbox-cell"></td>
                                 <td><a href="${item.entryUrl}">${item.entryName}</a></td>

--- a/src/assetbundles/src/js/RecentlyModified.js
+++ b/src/assetbundles/src/js/RecentlyModified.js
@@ -99,6 +99,7 @@
 
                                 $container.attr('data-id', item.entryId);
 
+                                item.entryName = item.entryName || 'Untitled';
                                 var widgetHtml = `
                                 <td id="check-${i}" class="entry-check checkbox-cell"></td>
                                 <td><a href="${item.entryUrl}">${item.entryName}</a></td>


### PR DESCRIPTION
## Pull Request

### Description:

Fixes the null entry showing up on the dashboard when fetching new and modified source entries. 

### Related Issue(s):

- [ ] [#561](https://github.com/AcclaroInc/pm-craft-translations/issues/561)

- 

### Changes Made:

 - When retrieving the list of entries, there are certain entries that have title as hidden, under these circumstances we get them as "Null" - now, the change here is to check for null and provide a default "Untitled" msg to make sure that the entry records exits and can be accessed. 

### Testing:

1. Create a new source entry or modify an existing one
2. Save the changes
3. Check the source entries display
4. Observe that instead of actual content, "Null" is shown for new entries
5. For modified entries, only slugs are visible instead of full content changes


### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**

![image](https://github.com/user-attachments/assets/52df85b4-21fb-4e5b-ba5d-5e8523874130)


### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.
