### PR TITLE
fixed: neo block issue

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "v4.0.2",
+    "pluginVersion": "v4.0.3",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.3 - 2024-12-13
+
+### Fixed
+- Neo blocks overwriting content in other sites on draft creation. ([AcclaroInc#562](https://github.com/AcclaroInc/pm-craft-translations/issues/562))
+
 ## 4.0.2 - 2024-11-21
 
 ### Fixed

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -698,7 +698,7 @@ class Translations extends Plugin
 				if ($currentFile) {
 					$order = self::$plugin->orderRepository->getOrderById($currentFile->orderId);
 
-                    $currentFile->status = Constants::FILE_STATUS_CANCELED;
+                    $currentFile->status = Constants::FILE_STATUS_REVIEW_READY;
 
                     self::$plugin->fileRepository->saveFile($currentFile);
 

--- a/src/services/fieldtranslator/NeoFieldTranslator.php
+++ b/src/services/fieldtranslator/NeoFieldTranslator.php
@@ -111,17 +111,24 @@ class NeoFieldTranslator extends GenericFieldTranslator
         foreach ($blocks as $i => $block) {
             $i = 'new' . ++$new;
 
-            $blockId = $field->getIsTranslatable($element) ? $i : $block->id;
+            $isTranslatable = $field->getIsTranslatable($element);
+            $blockId = $isTranslatable ? $i : $this->getBlockUid($block);
             $blockData = $allBlockData[$i] ?? array();
 
-            $post[$fieldHandle][$blockId] = array(                
+            $data = [
                 'modified' => '1',
                 'type' => $block->getType()->handle,
                 'enabled' => $block->enabled,
                 'collapsed' => $block->collapsed,
                 'level' => $block->level,
-                'fields' => $elementTranslator->toPostArrayFromTranslationTarget($block, $sourceLanguage, $targetLanguage, $blockData, true),
-            );
+                'fields' => $elementTranslator->toPostArrayFromTranslationTarget($block, $sourceLanguage, $targetLanguage, $blockData, true),                
+            ];
+
+            if ($isTranslatable) {
+                $post[$fieldHandle][$blockId] = $data;
+            } else {
+                $post[$fieldHandle]['blocks'][$blockId] = $data;
+            }
         }
 
         return $post;
@@ -147,6 +154,11 @@ class NeoFieldTranslator extends GenericFieldTranslator
         return $wordCount;
     }
 
+    private function getBlockUid($block)
+    {
+        return sprintf('uid:%s', $block->getCanonicalUid());
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -165,13 +177,23 @@ class NeoFieldTranslator extends GenericFieldTranslator
         );
 
         foreach ($blocks as $i => $block) {
+            $isTranslatable = $field->getIsTranslatable($element);
+            $blockId = $isTranslatable ? $i : $this->getBlockUid($block);
 
-            $blockId = $block->id ?? sprintf('new%s', ++$i);
-            $post[$fieldHandle][$blockId] = array(
+            $data = [
+                'modified' => '1',
                 'type' => $block->getType()->handle,
                 'enabled' => $block->enabled,
-                'fields' => $elementTranslator->toPostArray($block),
-            );
+                'collapsed' => $block->collapsed,
+                'level' => $block->level,
+                'fields' => $elementTranslator->toPostArray($block)
+            ];
+
+            if ($isTranslatable) {
+                $post[$fieldHandle][$blockId] = $data;
+            } else {
+                $post[$fieldHandle]['blocks'][$blockId] = $data;
+            }
         }
 
         return $post;


### PR DESCRIPTION
## Pull Request

### Description:
Focuses on resolving block propagation issues related to nested fields neo handling localised and non localised blocks when creating & merging drafts.

### Related Issue(s):

- [#562](https://github.com/AcclaroInc/pm-craft-translations/issues/562)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

- The block structure when merging in translated content for neo blocks.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


