### PR TITLE
#564: Migration fix for program id missing

### DIFF
--- a/src/migrations/m241216_081944_upsert_program_id_column.php
+++ b/src/migrations/m241216_081944_upsert_program_id_column.php
@@ -7,18 +7,27 @@ use Craft;
 use craft\db\Migration;
 
 /**
- * m240808_084903_add_program_id_to_orders migration.
+ * m241216_081944_upsert_program_id_column migration.
  */
-class m240808_084903_add_program_id_to_orders extends Migration
+class m241216_081944_upsert_program_id_column extends Migration
 {
     /**
      * @inheritdoc
      */
     public function safeUp(): bool
     {
-        echo "Adding translations_orders requestQuote column...\n";
-        $this->addColumn(Constants::TABLE_ORDERS, 'programId', $this->integer()->null()->after('ownerId'));
-        echo "Done adding translations_orders requestQuote column...\n";
+        $tableName = Constants::TABLE_ORDERS;
+        $columnName = 'programId';
+
+        // Check if the column exists
+        if (!$this->db->columnExists($tableName, $columnName)) {
+
+            $this->addColumn($tableName, $columnName, $this->integer()->null()->after('ownerId'));
+
+            Craft::info("Added column '{$columnName}' to table '{$tableName}'", __METHOD__);
+        } else {
+            Craft::info("Column '{$columnName}' already exists in table '{$tableName}'", __METHOD__);
+        }
 
         return true;
     }


### PR DESCRIPTION
## Pull Request

### Description:

 Adding a migration to fix the program Id missing in the orders table. 

### Related Issue(s):

- [ ] [#564](https://github.com/AcclaroInc/pm-craft-translations/issues/564)
- [ ] #532 

- 

### Changes Made:

**Added:**
  - Added a new migration that runs and checks if program id exists, if not - adds it to the table. 
- 

**Fixed:**
  - fixed the rollback method by adding a proper check to prevent rollback failures. 
-

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.
