### PR TITLE
fixed: error adding entry to existing order

### DIFF
--- a/src/services/repository/FileRepository.php
+++ b/src/services/repository/FileRepository.php
@@ -351,7 +351,7 @@ class FileRepository
 
     public function createOrderFile($order, $elementId, $targetSite)
     {
-        $element = Translations::$plugin->elementRepository->getElementById($elementId);
+        $element = Translations::$plugin->elementRepository->getElementById($elementId, $order->sourceSite);
         $wordCount = Translations::$plugin->elementTranslator->getWordCount($element) ?? 0;
 
         $file = $this->makeNewFile();


### PR DESCRIPTION
## Pull Request

### Description:
Entry in default site not found leading to error adding entry to existing order.

### Related Issue(s):

- #538 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- Source site specifically when fetching an order preventing error if source site does not exist in default site.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


