### PR TITLE
Bp/575/table maker plugin support for craft5

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -288,6 +288,7 @@ class Constants
         'craft\fields\RadioButtons',
         'benf\neo\Field',
         'verbb\vizy\fields\VizyField',
+        'verbb\tablemaker\fields\TableMakerField',
         'craft\redactor\Field',
         'presseddigital\linkit\fields\LinkitField',
         'verbb\hyper\fields\HyperField',

--- a/src/services/fieldtranslator/Factory.php
+++ b/src/services/fieldtranslator/Factory.php
@@ -45,6 +45,7 @@ use verbb\supertable\fields\SuperTableField;
 use lenz\linkfield\fields\LinkField as TypedLinkField;
 use verbb\hyper\fields\HyperField as HyperLinkField;
 use verbb\navigation\fields\NavigationField;
+use verbb\tablemaker\fields\TableMakerField;
 
 class Factory
 {
@@ -78,7 +79,8 @@ class Factory
         Embed::class            => NsmFieldsTranslator::class,
         VizyField::class  	    => VizyFieldTranslator::class,
         NavigationField::class  => NavigationFieldTranslator::class,
-        CkEditorField::class    => GenericFieldTranslator::class
+        CkEditorField::class    => GenericFieldTranslator::class,
+        TableMakerField::class  => TableMakerFieldTranslator::class
     );
 
     public function makeTranslator(Field $field)

--- a/src/services/fieldtranslator/TableMakerFieldTranslator.php
+++ b/src/services/fieldtranslator/TableMakerFieldTranslator.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Translations for Craft plugin for Craft CMS 5.x
+ *
+ * Translations for Craft eliminates error prone and costly copy/paste workflows for launching human translated Craft CMS web content.
+ *
+ * @link      http://www.acclaro.com/
+ * @copyright Copyright (c) 2018 Acclaro
+ */
+
+namespace acclaro\translations\services\fieldtranslator;
+
+use craft\base\Field;
+use craft\base\Element;
+use acclaro\translations\Translations;
+use acclaro\translations\services\ElementTranslator;
+
+class TableMakerFieldTranslator extends GenericFieldTranslator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $source = array();
+
+        $data = $element->getFieldValue($field->handle);
+
+        $columnsData = $data['columns'];
+        $columns = $this->getTableColumns($columnsData);
+        
+        foreach ($data['rows'] as $i => $row) {
+            foreach ($columns as $id => $name) {
+                $key = sprintf('%s.%s.%s', $field->handle, $i, $name);
+
+                // Check to translate dropdown lable not values
+                if ($this->isColumnDropdown($columnsData[$id])) {
+                    $source[$key] = $columnsData[$id]['options'][$i]['label'];
+                } else {
+                    $source[$key] = isset($row[$id]) ? $row[$id] : '';
+                }
+            }
+        }
+        return $source;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toPostArray(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $fieldHandle = $field->handle;
+
+        $fieldData = $element->getFieldValue($fieldHandle);
+
+        return $fieldData ? array($fieldHandle => $fieldData) : array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite, $targetSite, $fieldData)
+    {
+        $fieldHandle = $field->handle;
+
+        $post = $this->toPostArray($elementTranslator, $element, $field);
+
+        foreach ($fieldData as $i => $row) {
+            if (isset($post[$fieldHandle]['rows'][$i])) {
+                // Custom logic to replace the dropdown lable in place of value
+                $this->handleDropdownValues($post, $row, $fieldHandle, $i);
+                $post[$fieldHandle]['rows'][$i] = array_values($row);
+            }
+        }
+        return $post;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWordCount(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $wordCount = 0;
+
+        $data = $element->getFieldValue($field->handle);
+
+        $columns = $this->getTableColumns($data['columns']);
+        
+        foreach ($data['rows'] as $i => $row) {
+            foreach ($columns as $id => $name) {
+                $value = $row[$id] ?? "";
+
+                $wordCount += Translations::$plugin->wordCounter->getWordCount($value);
+            }
+        }
+
+        return $wordCount;
+    }
+
+    private function getTableColumns($columnsData)
+    {
+        $columns = [];
+
+        foreach ($columnsData as $info) {
+            array_push($columns, $info['heading']);
+        }
+
+        return $columns;
+    }
+
+    private function isColumnDropdown($columnsData)
+    {
+        return $columnsData['type'] === 'select';
+    }
+
+    private function handleDropdownValues(&$post, &$row, $fieldHandle, $i)
+    {
+        $columnsData = $post[$fieldHandle]['columns'];
+        $columns = $this->getTableColumns($columnsData);
+
+        foreach ($columns as $id => $name) {
+            if ($this->isColumnDropdown($columnsData[$id])) {
+                foreach ($post[$fieldHandle]['columns'][$id]['options'] as $index => $dd) {
+                    if ($dd['value'] === $post[$fieldHandle]['rows'][$i][$id]) {
+                        $post[$fieldHandle]['columns'][$id]['options'][$index]['label'] = $row[$name];
+                        $row[$name] = $post[$fieldHandle]['rows'][$i][$id];
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/services/fieldtranslator/TableMakerFieldTranslator.php
+++ b/src/services/fieldtranslator/TableMakerFieldTranslator.php
@@ -31,6 +31,9 @@ class TableMakerFieldTranslator extends GenericFieldTranslator
         
         foreach ($data['rows'] as $i => $row) {
             foreach ($columns as $id => $name) {
+                $columnKey = sprintf('%s.%s.%s', $field->handle, 'columnTitle', $id);
+                $source[$columnKey] = $name;
+
                 $key = sprintf('%s.%s.%s', $field->handle, $i, $name);
 
                 // Check to translate dropdown lable not values
@@ -62,11 +65,14 @@ class TableMakerFieldTranslator extends GenericFieldTranslator
     public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite, $targetSite, $fieldData)
     {
         $fieldHandle = $field->handle;
-
         $post = $this->toPostArray($elementTranslator, $element, $field);
 
         foreach ($fieldData as $i => $row) {
-            if (isset($post[$fieldHandle]['rows'][$i])) {
+            if ($i === 'columnTitle') {
+                foreach ($row as $index => $columnTitle) {
+                    $post[$fieldHandle]['columns'][$index]['heading'] = $columnTitle;
+                }
+            } else if (isset($post[$fieldHandle]['rows'][$i])) {
                 // Custom logic to replace the dropdown lable in place of value
                 $this->handleDropdownValues($post, $row, $fieldHandle, $i);
                 $post[$fieldHandle]['rows'][$i] = array_values($row);


### PR DESCRIPTION
## Pull Request

### Description:
Support for translation of new plugin table maker by verbb. (Only fields translatable are dropdown, multi-line-text & single-line-text)

### Related Issue(s):

- [Support table maker plugin](https://github.com/AcclaroInc/pm-craft-translations/issues/575)

### Changes Made:

**Added:**

- New table maker translator.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Tested on local setup. Video added to ticket to see things in action.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [x] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Table maker plugin demo.webm](https://github.com/user-attachments/assets/f126b5b3-09e1-4b2f-98d8-584e0daecb75)


### Wrapping up

**Checklist:**

- [x] The code builds without any errors or warnings.
- [x] The code follows the project's coding conventions and style guidelines.
- [x] Unit tests have been added or updated to cover the changes made.
- [x] The documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**

@qa-mukesh [This](https://dev.acclarocraft.com/admin/translations/orders/detail/94486?site=default) order can be used for testing the plugin on dev instance.