### PR TITLE
Activity log future date issue fix

### DIFF
--- a/src/services/repository/ActivityLogRepository.php
+++ b/src/services/repository/ActivityLogRepository.php
@@ -40,7 +40,7 @@ class ActivityLogRepository
             $activityLog = $this->makeNewActivityLogModel();
             $activityLog->targetId = $target->id;
             $activityLog->message = $message;
-            $activityLog->created = date('Y-m-d H:i:s');
+            $activityLog->created = Craft::$app->getFormatter()->asDatetime('now', 'php:Y-m-d H:i:s');
             $activityLog->targetClass = get_class($target);
 
             return $this->saveActivityLog($activityLog);


### PR DESCRIPTION
## Pull Request

### Description:
Though we are not able to find the concrete cause why did that happened in first place, However we have added craft's native date function for activity log date logging to prevent any such issue.

### Related Issue(s):

- #539 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]

**Logs after changes**
![image](https://github.com/user-attachments/assets/377100fe-af86-448f-a114-1319b55672a6)

