### PR TITLE
Update docs/faq.md: static translations

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,6 +65,22 @@ Yes, we recommend testing the Translation plugin and localization workflow on a 
 
 ## Technical Issues
 
+<details><summary>Why are my static translations being overwritten in production?</summary>
+
+Static translation files (e.g., `/translations/es/Site.php`) can sometimes overwrite production values during deployment. To prevent this, you have two options:
+
+1. Add the `/translations` folder to your `.gitignore` file to prevent the files from being pushed to production.
+
+2. Set a custom translations path for production by adding this to your `web/index.php`:
+
+    ```php
+    define('CRAFT_TRANSLATIONS_PATH', CRAFT_BASE_PATH.'/static-translations');
+    ```
+
+    This will store translations in a separate directory that won't be overwritten during deployments.
+
+</details>
+
 <details><summary>How do I display translated values for dropdown, multi-select, and radio fields?</summary>
 
 To display translated string values for these fields, use the Twig `|t` filter with the 'translations' category in your templates. For example: `'some string'|t('translations')`.


### PR DESCRIPTION
Update docs/faq.md: Added new section on preventing static translations from being overwritten in production

- Added a new section under "Technical Issues" explaining how to prevent static translation files from being overwritten in production