### PR TITLE
fixed: feedback widget overlapping

### DIFF
--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -408,8 +408,8 @@ body.ltr .widget[data-type="acclaro\\translations\\widgets\\NewAndModifiedEntrie
     transition: all 0.05s ease-in-out;
 }
 
-#recent-entries-widget {
-    display: grid;
+#recent-entries-widget, #recently-modified-widget {
+    display: flow-root;
 }
 
 #recent-entries-widget .view-diff-entry {

--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -408,6 +408,10 @@ body.ltr .widget[data-type="acclaro\\translations\\widgets\\NewAndModifiedEntrie
     transition: all 0.05s ease-in-out;
 }
 
+#recent-entries-widget {
+    display: grid;
+}
+
 #recent-entries-widget .view-diff-entry {
     transition: all 0.05s ease-in-out;
 }
@@ -420,7 +424,7 @@ body.ltr .widget[data-type="acclaro\\translations\\widgets\\NewAndModifiedEntrie
     border-bottom: 1px dotted #e3e5e8;
     display: flex;
     justify-content: flex-start;
-    padding: 10px 0px;
+    padding: 10px 10px;
 }
 
 #diff-modal .instructions, #diff-modal-entry .instructions {
@@ -430,6 +434,7 @@ body.ltr .widget[data-type="acclaro\\translations\\widgets\\NewAndModifiedEntrie
 #diff-modal .modal-title, #diff-modal-entry .modal-title {
     display: flex;
     justify-content: space-between;
+    align-items: baseline;
 }
 
 #duplicate-modal {
@@ -959,10 +964,6 @@ td.target{
 .diff-box{
     box-shadow: 0 0 0 1px #cdd8e4, 0 2px 12px rgba(205, 216, 228, 0.5);
     border-radius: 5px;
-}
-
-.diff-meta{
-    padding: 24px 0 12px
 }
 
 .bg-none {

--- a/src/assetbundles/src/js/RecentEntries.js
+++ b/src/assetbundles/src/js/RecentEntries.js
@@ -49,7 +49,7 @@
                         var content = [];
 
                         if (response.data.length) {
-                            this.$widget.find('#recent-entries-widget .tableview').prepend('<h2 style="padding-top: 24px;">New Source Entries</h2><h5>Entries that have not been translated yet.</h5>');
+                            this.$widget.find('#recent-entries-widget .elements').prepend('<h2 style="padding-top: 2px;">New Source Entries</h2><h5>Entries that have not been translated yet.</h5>');
                             for (var i = 0; i < response.data.length; i++) {
                                 var item = response.data[i],
                                     $container = $('#item-entry-'+ (i + 1));

--- a/src/assetbundles/src/js/RecentlyModified.js
+++ b/src/assetbundles/src/js/RecentlyModified.js
@@ -90,7 +90,7 @@
                         var content = [];
 
                         if (response.data.length) {
-                            this.$widget.find('#recently-modified-widget .tableview').prepend('<h2 style="padding-top: 24px;">Modified Source Entries</h2><h5>Entries that have been modified post-translation.</h5>');
+                            this.$widget.find('#recently-modified-widget .elements').prepend('<h2 style="padding-top: 2px;">Modified Source Entries</h2><h5>Entries that have been modified post-translation.</h5>');
                             for (var i = 0; i < response.data.length; i++) {
                                 var item = response.data[i],
                                     $container = $('#item-'+ (i + 1));

--- a/src/templates/_components/widgets/NewAndModifiedEntries/body.twig
+++ b/src/templates/_components/widgets/NewAndModifiedEntries/body.twig
@@ -30,19 +30,19 @@
                         <tr id="item-{{i}}">&nbsp;</tr>
                     {% endfor %}
                 </table>
-                <div class="buttons right">
-                    {{ button.anchorButton({
-                        label: 'Re-order'|t('app'),
-                        id: 'bulk-reorder',
-                        class: 'link-disabled icon submit',
-                        attributes: {
-                            target: '_blank',
-                            data: {
-                                icon: 'language'
-                            }
+            </div>
+            <div class="buttons right">
+                {{ button.anchorButton({
+                    label: 'Re-order'|t('app'),
+                    id: 'bulk-reorder',
+                    class: 'link-disabled icon submit',
+                    attributes: {
+                        target: '_blank',
+                        data: {
+                            icon: 'language'
                         }
-                    }) }}
-                </div>
+                    }
+                }) }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Pull Request

### Description:
Fixed feedback widget overlapping, some buttons extending outside parent divs & text alignment issues.

### Related Issue(s):

- [#560](https://github.com/AcclaroInc/pm-craft-translations/issues/560)

### Changes Made:

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**

Before fix:
![image](https://github.com/user-attachments/assets/9bce5549-5c9b-438f-95ff-8741297d98cd)
![image](https://github.com/user-attachments/assets/31cdebf1-ee2c-4cfb-95e9-11ae233d3bc0)


After fix:
![image](https://github.com/user-attachments/assets/83530ea3-42f2-4068-b3a4-1fdd58331923)
![image](https://github.com/user-attachments/assets/c8839bca-dde1-4cee-a6a2-1d7c3c9ab937)

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


