### PR TITLE
Fixed: Multiple draft content reversion issue

### DIFF
--- a/src/Translations.php
+++ b/src/Translations.php
@@ -689,7 +689,8 @@ class Translations extends Plugin
 
     private function _onDeleteElement(Event $event)
     {
-		if (!empty($event->element->draftId)) {
+        // Only execute on hard delete not on trashing drafts
+		if (!empty($event->element->draftId) && $event->hardDelete) {
 			$response = self::$plugin->draftRepository->isTranslationDraft($event->element->draftId);
 			if ($response) {
 


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Fixed multiple parallel draft content revert issue when applied.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- [#589](https://github.com/AcclaroInc/pm-craft-translations/issues/589)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added soft-delete and restore for translation drafts

- Implemented trash and restore logic in createOrderDrafts

- Modified element deletion to require hard delete

- Expanded file readiness check to include complete state


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Translations.php</strong><dd><code>Only delete drafts on hard delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Translations.php

<li>Guard draft deletion on hardDelete flag<br> <li> Skip trashing drafts when not hard deleting<br> <li> Preserve translation drafts on soft delete


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/570/files#diff-5dbabf28f99c5bb5952de16ae00245df569895ed48a3a196b329c34bb48ce8f9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DraftRepository.php</strong><dd><code>Soft-delete, trash & restore draft logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/DraftRepository.php

<li>Added getTrashedDraftById and restoreDraft methods<br> <li> Changed deleteDraft to support soft/hard deletion<br> <li> Trash existing drafts before publish and restore after<br> <li> Included isComplete in file readiness check


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/570/files#diff-4885c24694510a7cf322200be77380b1218416eff7332687469fc6a4fd8dd0d8">+56/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>