### PR TITLE
fixed: draft creations changes reverting issue

### DIFF
--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -192,13 +192,13 @@ class DraftRepository
         $createDrafts = new CreateDrafts();
         
         foreach ($order->getFiles() as $file) {
-            /* Create transaction per file so that in case a file has validation error
-            only that will be rolledback and others can be processed */
-            $transaction = Craft::$app->db->beginTransaction();
-
             if (! in_array($file->id, $fileIds)) {
                 continue;
             }
+
+            /* Create transaction per file so that in case a file has validation error
+            only that will be rolledback and others can be processed */
+            $transaction = Craft::$app->db->beginTransaction();
 
             $element = Translations::$plugin->elementRepository->getElementById($file->elementId, $order->sourceSite);
             $isFileReady = $file->isReviewReady();


### PR DESCRIPTION
### **User description**
### Related Issue(s):

- [#589](https://github.com/AcclaroInc/pm-craft-translations/issues/589)

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- Create an order.
- Download source files.
- Pseudo translate the files.
- Upload translated files.
- Merge into draft files one by one.
- Verify all drafts are created successfully.
- Do try reloading page after each merge to ensure the changes are not reverting.

___

### **PR Type**
Bug fix


___

### **Description**
- Move transaction start below file inclusion check

- Prevent unnecessary transactions for skipped files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DraftRepository.php</strong><dd><code>Relocate transaction initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/DraftRepository.php

<li>Moved <code>beginTransaction</code> call below <code>if (! in_array($file->id, $fileIds))</code> <br>check<br> <li> Ensures transactions only open for selected files


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/571/files#diff-4885c24694510a7cf322200be77380b1218416eff7332687469fc6a4fd8dd0d8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>


___

### **PR Type**
Bug fix


___

### **Description**
- Move transaction start below file inclusion check

- Prevent unnecessary transactions for skipped files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DraftRepository.php</strong><dd><code>Relocate transaction initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/DraftRepository.php

<li>Relocated <code>beginTransaction</code> call after file inclusion check<br> <li> Avoided starting transactions for skipped files


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/572/files#diff-4885c24694510a7cf322200be77380b1218416eff7332687469fc6a4fd8dd0d8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>