### PR TITLE
fixed: field duplication issue

### DIFF
--- a/src/services/fieldtranslator/MatrixFieldTranslator.php
+++ b/src/services/fieldtranslator/MatrixFieldTranslator.php
@@ -63,8 +63,11 @@ class MatrixFieldTranslator extends GenericFieldTranslator
         foreach ($blocks as $i => $block) {
             $blockId = $block->id ?? sprintf('new%s', ++$i);
             $post[$fieldHandle][$blockId] = array(
-                'type'              => $block->getType()->handle,
-                'enabled'           => $block->enabled,
+                'title'         => $block->title,
+                'slug'          => $block->slug,
+                'type'          => $block->getType()->handle,
+                'enabled'       => $block->enabled,
+                'collapsed'     => $block->collapsed,
                 'fields'            => $elementTranslator->toPostArray($block),
             );
         }
@@ -94,8 +97,12 @@ class MatrixFieldTranslator extends GenericFieldTranslator
              */
             $blockId = $field->getIsTranslatable($element) ? $i : $block->id;
             $blockData = $fieldData[$i] ?? array();
+            $title = isset($blockData['title']) ? $blockData['title'] : $block->title; 
+            $slug = isset($blockData['slug']) ? $blockData['slug'] : $block->slug; 
 
             $post[$fieldHandle][$blockId] = array(
+                'title'             => $title,
+                'slug'              => $slug,
                 'type'              => $block->getType()->handle,
                 'enabled'           => $block->getAttributes()['enabled'],
                 'collapsed'         => $block->getAttributes()['collapsed'],

--- a/src/services/translator/Export_ImportTranslationService.php
+++ b/src/services/translator/Export_ImportTranslationService.php
@@ -232,7 +232,7 @@ class Export_ImportTranslationService implements TranslationServiceInterface
                 $draft->slug = isset($targetData['slug']) ? $targetData['slug'] : $draft->slug;
 
                 /** Use source entry as first argument as the draft in target site might have different block structure as compared to source leading into missing some blocks */
-                $post = Translations::$plugin->elementTranslator->toPostArrayFromTranslationTarget($element, $sourceSite, $targetSite, $targetData);
+                $post = Translations::$plugin->elementTranslator->toPostArrayFromTranslationTarget($draft, $sourceSite, $targetSite, $targetData);
                 $draft->setFieldValues($post);
                 $draft->siteId = $targetSite;
 


### PR DESCRIPTION
## Pull Request

### Description:
Fixed matrix field block duplication issue, introduced due to craft recent changes of matrix blocks being saved as an entry.

### Related Issue(s):

- 

### Changes Made:
**Added:**

- slug fields to matrix blocks.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Tested locally. **Deployed to staging for QA.**

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional/Testing Notes:**
- Created nested matrix blocks with in a section.
- Create entry using that section.
- Create local order using above entry.
- Pseudo translate the source file and upload back
- Create draft.
- Apply draft (Do not merge and apply in single attempt..)
- Check content of source entry gets changed for all sites.

