### PR TITLE
fixed: supertable field translation issue

### DIFF
--- a/src/services/fieldtranslator/SuperTableFieldTranslator.php
+++ b/src/services/fieldtranslator/SuperTableFieldTranslator.php
@@ -13,7 +13,6 @@ namespace acclaro\translations\services\fieldtranslator;
 
 use craft\base\Field;
 use craft\base\Element;
-use verbb\supertable\SuperTable;
 use craft\elements\db\ElementQuery;
 use acclaro\translations\services\ElementTranslator;
 
@@ -92,7 +91,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 			$fieldHandle => array(),
 		);
 
-		$blockTypes = SuperTable::$plugin->service->getBlockTypesByFieldId($field->id);
+		$blockTypes = $this->getBlockTypesByFieldId($field->id);
 
 		$blockType = $blockTypes[0] ?? $blockTypes; // There will only ever be one SuperTable_BlockType
 
@@ -149,7 +148,7 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 			$fieldHandle => array(),
 		);
 
-		$blockTypes = SuperTable::$plugin->service->getBlockTypesByFieldId($field->id);
+		$blockTypes = $this->getBlockTypesByFieldId($field->id);
 
 		$blockType = $blockTypes[0]; // There will only ever be one SuperTable_BlockType
 
@@ -227,5 +226,22 @@ class SuperTableFieldTranslator extends GenericFieldTranslator
 		}
 
 		return $wordCount;
+	}
+
+	/**
+	 * Retrieves the list of entry types (block types) for a Super Table field.
+	 *
+	 * In Super Table v5, blocks are stored as native Craft entries, and each field
+	 * is associated with one or more entry types. This method fetches those entry types
+	 * for a given field ID.
+	 *
+	 * @param int $fieldId The ID of the Super Table field.
+	 * @return array The array of EntryType models representing Super Table block types.
+	 */
+	public function getBlockTypesByFieldId(int $fieldId): array
+	{
+		$field = \Craft::$app->getFields()->getFieldById($fieldId);
+
+		return $field->getEntryTypes();
 	}
 }


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Fixed an issue where super-table field (which is officially deprecated in craft 5) in craft 5 is used in translation entry.

### Related Issue(s):

- [#601](https://github.com/AcclaroInc/pm-craft-translations/issues/601)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

- Logic used to retrieve and merge in super-table blocks.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Tested with new supertable field created in craft 5.
- Tested witthout migrating supertable blocks to matrix after craft4 to 5 upgrade. 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added method to fetch SuperTable block entry types

- Replaced plugin service calls with new helper

- Removed unused `verbb\supertable\SuperTable` import

- Enhanced Craft 5 SuperTable translation support


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SuperTableFieldTranslator.php</strong><dd><code>Use entry types for SuperTable blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/fieldtranslator/SuperTableFieldTranslator.php

<li>Removed <code>use verbb\supertable\SuperTable</code> import<br> <li> Updated <code>toPostArray</code> and <code>toPostArrayFromTranslationTarget</code> methods<br> <li> Added <code>getBlockTypesByFieldId</code> to retrieve entry types<br> <li> Replaced direct plugin service calls for block types


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/583/files#diff-c479244da263410235c4d77f7f471c46b50070105b012ff75437ee1a611a47c0">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>