### PR TITLE
Fixed: widgets timeout when loading dashboard

### DIFF
--- a/src/assetbundles/src/js/LanguageCoverage.js
+++ b/src/assetbundles/src/js/LanguageCoverage.js
@@ -27,11 +27,7 @@
                     autoShow: false,
                 });
 
-                var $data = {
-                    limit: params
-                };
-
-                Craft.sendActionRequest('POST', 'translations/widget/get-language-coverage', {data: $data})
+                Craft.sendActionRequest('POST', 'translations/widget/get-language-coverage', {data: params})
                     .then((response) => {
                         this.$widget.removeClass('loading');
                         this.$widget.find('.elements').removeClass('hidden');

--- a/src/assetbundles/src/js/RecentlyModified.js
+++ b/src/assetbundles/src/js/RecentlyModified.js
@@ -76,11 +76,7 @@
                     }
                 });
 
-                var $data = {
-                    limit: params
-                };
-
-                Craft.sendActionRequest('POST', 'translations/widget/get-recently-modified', {data: $data})
+                Craft.sendActionRequest('POST', 'translations/widget/get-recently-modified', {data: params})
                     .then((response) => {
                         this.$widget.removeClass('loading');
                         this.$widget.find('.elements').removeClass('hidden');

--- a/src/controllers/WidgetController.php
+++ b/src/controllers/WidgetController.php
@@ -296,7 +296,8 @@ class WidgetController extends BaseController
 
         // Set variables
         $limit = Craft::$app->getRequest()->getParam('limit');
-        $recentlyModifiedCallback = fn() => $this->service->getRecentlyModifiedEntries($limit);
+        $days = Craft::$app->getRequest()->getParam('days', '7');
+        $recentlyModifiedCallback = fn() => $this->service->getRecentlyModifiedEntries($limit, $days);
 
         $data = Translations::$plugin->cacheHelper->getOrSetCache(
             Constants::CACHE_KEY_RECENTLY_MODIFIED_WIDGET,

--- a/src/services/fieldtranslator/TableMakerFieldTranslator.php
+++ b/src/services/fieldtranslator/TableMakerFieldTranslator.php
@@ -116,7 +116,7 @@ class TableMakerFieldTranslator extends GenericFieldTranslator
 
     private function isColumnDropdown($columnsData)
     {
-        return $columnsData['type'] === 'select';
+        return isset($columnsData['type']) && $columnsData['type'] === 'select';
     }
 
     private function handleDropdownValues(&$post, &$row, $fieldHandle, $i)

--- a/src/services/repository/WidgetRepository.php
+++ b/src/services/repository/WidgetRepository.php
@@ -391,6 +391,10 @@ class WidgetRepository extends BaseComponent
         // Get array of entry IDs sorted by most recently updated
         $fromDate = (new \DateTime("-{$days} days"))->format(\DateTime::ATOM);
         $entries = Entry::find()
+            ->drafts(null)
+            ->draftOf(false)
+            ->provisionalDrafts(null)
+            ->revisions(null)
             ->sectionId(['not', null])
             ->dateCreated(">= {$fromDate}")
             ->orderBy(['dateCreated' => SORT_DESC])
@@ -453,15 +457,21 @@ class WidgetRepository extends BaseComponent
         return $data;
     }
 
-    public function getRecentlyModifiedEntries($limit): array
+    public function getRecentlyModifiedEntries($limit, $days): array
     {
         $files = [];
         $data = [];
         $i = 0;
 
+        $fromDate = (new \DateTime("-{$days} days"))->format(\DateTime::ATOM);
         // Get array of entry IDs sorted by most recently updated
         $entries = Entry::find()
             ->sectionId(['not', null])
+            ->drafts(null)
+            ->draftOf(false)
+            ->provisionalDrafts(null)
+            ->revisions(null)
+            ->dateUpdated(">= {$fromDate}")
             ->orderBy(['dateUpdated' => SORT_DESC])
             ->ids();
 
@@ -590,7 +600,10 @@ class WidgetRepository extends BaseComponent
                 // Get entries count
                 $enabledEntries = Entry::find()
                 ->site($site)
-                // ->enabledForSite()
+                ->sectionId(['not', null])
+                ->drafts(null)
+                ->draftOf(false)
+                ->revisions(null)
                 ->count();
 
                 // Get in progress entry translation count


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
[Provide a brief description of the purpose and goal of this pull request.]

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `days` parameter for widget entries

- Extend queries with drafts and revisions filters

- Simplify AJAX payloads to pass full params

- Fix dropdown type check guard


___

### **Changes diagram**

```mermaid
flowchart LR
  UI["Widget JS"] -- "sendActionRequest(data)" --> Controller["WidgetController"]
  Controller -- "getRecentlyModifiedEntries(limit, days)" --> Service["WidgetService"]
  Service -- "fetch entries/files" --> Repo["WidgetRepository"]
  Repo -- "apply date and draft filters" --> DB["Entries/Files"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WidgetController.php</strong><dd><code>Include days parameter in recent widget callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controllers/WidgetController.php

<li>Added <code>days</code> parameter defaulting to 7 days<br> <li> Updated callback to pass both <code>limit</code> and <code>days</code>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/587/files#diff-7a2fb292efc575db5d5236ca272c994bf627af4c8cf5dfb2bc07af508f5a450d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WidgetRepository.php</strong><dd><code>Optimize repository queries with date and draft filters</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/WidgetRepository.php

<li>Added <code>days</code> argument to recent entries methods<br> <li> Applied dateUpdated/dateCreated filters with days<br> <li> Included drafts, revisions, provisional draft filters<br> <li> Extended language coverage query filters


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/587/files#diff-72c8cf77be7f0f2394decd00b7c22046d02cb663e617c43afbbe4ce085b0aaa0">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LanguageCoverage.js</strong><dd><code>Simplify language coverage AJAX payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/LanguageCoverage.js

- Changed AJAX call to send full `params` directly


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/587/files#diff-206067728a894c1f9adb43f4c23f3d476405489543bf6f7d960af171f78b37da">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RecentlyModified.js</strong><dd><code>Simplify recently modified AJAX payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/RecentlyModified.js

- Changed AJAX call to send full `params` directly


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/587/files#diff-223de1d709b8071e9dfb51e81d32dd6747661356ee2b55eb22faf0b9a2b0c503">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableMakerFieldTranslator.php</strong><dd><code>Fix dropdown type detection guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/fieldtranslator/TableMakerFieldTranslator.php

- Guard `type` index with `isset` before check


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/587/files#diff-a3cdc9f0fd4afd14bc3014b7ef77755c3b9be297a5a6607dc1a8236decacd549">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>