### PR TITLE
Fixed: cpTrigger issue in url

### DIFF
--- a/src/assetbundles/src/js/OrderDetails.js
+++ b/src/assetbundles/src/js/OrderDetails.js
@@ -329,7 +329,7 @@
         let translatorId = getSelectedTranslator().val();
 
         // Construct the endpoint URL
-        const url = `/admin/translations/translators/${translatorId}/programs`;
+        const url = `/${Craft.cpTrigger}/translations/translators/${translatorId}/programs`;
 
         // Make the GET request
         fetch(url, {
@@ -957,7 +957,7 @@
                 sendingOrderStatus(true);
                 setUnloadEvent(false);
                 if ($(that).text() == "Create new order") {
-                    var url = window.location.origin+"/admin/translations/orders/create";
+                    var url = `${Craft.baseSiteUrl}/${Craft.cpTrigger}/translations/orders/create`;
                     $form.find("input[type=hidden][name=action]").val('translations/order/order-detail');
                     window.history.pushState("", "", url);
                     $('<input>', {

--- a/src/services/repository/OrderRepository.php
+++ b/src/services/repository/OrderRepository.php
@@ -273,7 +273,7 @@ class OrderRepository
 
         $totalElements = count($order->files);
         $currentElement = 0;
-        $orderUrl = UrlHelper::baseSiteUrl() .'admin/translations/orders/detail/'.$order->id;
+        $orderUrl = UrlHelper::baseSiteUrl(). UrlHelper::prependCpTrigger('translations/orders/detail/'.$order->id);
         $orderUrl = "Craft Order: <a href='$orderUrl'>$orderUrl</a>";
         $comments = $order->comments ? $order->comments .' | '.$orderUrl : $orderUrl;
         $dueDate = $order->requestedDueDate;

--- a/src/templates/settings/clear-orders.twig
+++ b/src/templates/settings/clear-orders.twig
@@ -24,8 +24,17 @@
         <h3>{{ 'Need a fresh start?'|t('app') }}</h3>
         {{ 'Clear all translation orders.'|t('app') }}
     </div>
+    {% set redirectUrl = "/" ~ craft.app.config.general.cpTrigger ~ "/translations/settings/clear-orders" %}
     <div class="buttons">
-        <button type="button" data-confirm="{{ 'Are you sure you want to continue?'|t }}" class="formsubmit btn submit icon" data-icon="trash" data-redirect="{{ '/admin/translations/settings/clear-orders' }}" value="submit">{{ "Clear orders"|t('app') }}</button>&nbsp;&nbsp;
+        <button
+        type="button"
+        data-confirm="{{ 'Are you sure you want to continue?'|t }}"
+        class="formsubmit btn submit icon"
+        data-icon="trash"
+        data-redirect="{{ redirectUrl }}"
+        value="submit">
+            {{ "Clear orders"|t('app') }}
+        </button>&nbsp;&nbsp;
     </div>
     <span class="warning" title="{{ 'Warning'|t('app') }}" data-icon="alert">{{' This action cannot be undone'}}</span>
 </form>

--- a/src/templates/settings/settings-check.twig
+++ b/src/templates/settings/settings-check.twig
@@ -2,6 +2,7 @@
 {% import "_includes/forms" as forms %}
 
 {% set title = 'Settings Check'|t %}
+{% set cpTrigger = craft.app.config.general.cpTrigger %}
 
 {% block header %}
     {{ parent() }}
@@ -55,7 +56,10 @@
                         <span class="success" title="{{ 'Passed'|t('app') }}" data-icon="check"></span>
                     {% endif %}
                 </td>
-                <td>Is MultiSite <span class="info">{{ 'Multiple Sites are required. <a href="/admin/settings/sites">Configure your Sites</a>' }}</span></td>
+                <td>Is MultiSite <span class="info">
+                    Multiple Sites are required. 
+                    <a href="/{{cpTrigger}}/settings/sites">Configure your Sites</a>
+                </span></td>
             </tr>
         </tbody>
     </table>
@@ -86,19 +90,19 @@
                         {% switch section.propagationMethod.value %}
                             {% case 'none' %}
                                 {{'Only save entries to the site they were created in'|t('app')}}
-                                <span class="info">Section propagation is required to create translation drafts within this section. <a href="/admin/settings/sections/{{section.id}}">Configure your Sections</a></span>
+                                <span class="info">Section propagation is required to create translation drafts within this section. <a href="/{{cpTrigger}}/settings/sections/{{section.id}}">Configure your Sections</a></span>
                             {% case 'siteGroup' %}
                                 {{'Save entries to other sites in the same site group'|t('app')}}
-                                <span class="info">With this propagation method, translation drafts can only be created within the same site group. <a href="/admin/settings/sections/{{section.id}}">Configure your Sections</a></span>
+                                <span class="info">With this propagation method, translation drafts can only be created within the same site group. <a href="/{{cpTrigger}}/settings/sections/{{section.id}}">Configure your Sections</a></span>
                             {% case 'language' %}
                                 {{'Save entries to other sites with the same language'|t('app')}}
-                                <span class="info">With this propagation method, translation drafts can only be created for sites with the same language. <a href="/admin/settings/sections/{{section.id}}">Configure your Sections</a></span>
+                                <span class="info">With this propagation method, translation drafts can only be created for sites with the same language. <a href="/{{cpTrigger}}/settings/sections/{{section.id}}">Configure your Sections</a></span>
                             {% case 'all' %}
                                 {{'Save entries to all sites enabled for this section'|t('app')}}
-                                <span class="info">With this propagation method, translation drafts can be created for all enabled sites. <a href="/admin/settings/sections/{{section.id}}">Configure your Sections</a></span>
+                                <span class="info">With this propagation method, translation drafts can be created for all enabled sites. <a href="/{{cpTrigger}}/settings/sections/{{section.id}}">Configure your Sections</a></span>
                             {% case 'custom' %}
                                 {{'Let each entry choose which sites it should be saved to'|t('app')}}
-                                <span class="info">With this propagation method, translation drafts can be created for specifically enabled sites. <a href="/admin/settings/sections/{{section.id}}">Configure your Sections</a></span>
+                                <span class="info">With this propagation method, translation drafts can be created for specifically enabled sites. <a href="/{{cpTrigger}}/settings/sections/{{section.id}}">Configure your Sections</a></span>
                         {% endswitch %}
                     </td>
                 </tr>


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
The user seeing a 404 page not found issue, I bealive it could be due to different cpTrigger than admin so changes the logic to fetch cpTrigger dynamically.

### Related Issue(s):

- [#619](https://github.com/AcclaroInc/pm-craft-translations/issues/619)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

- The hard coded cpTrigger to dynamic.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Do not have steps to reproduce, so sid or merrit can QA this once its deployed to dev server.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Enhancement


___

### **Description**
- Use dynamic cpTrigger in backend URLs

- Replace hardcoded '/admin' in PHP service

- Update JS endpoints to use `Craft.cpTrigger`

- Adjust Twig templates for dynamic CP links


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrderRepository.php</strong><dd><code>Use dynamic cpTrigger in order URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/OrderRepository.php

<ul><li>Use UrlHelper::prependCpTrigger for order URLs<br> <li> Remove hardcoded 'admin' segment</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/596/files#diff-ddaa408fb195296a4cf138ddcb0dac99d49d3601c64e496f5cfcbff65511a2d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrderDetails.js</strong><dd><code>Dynamic cpTrigger in JS endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/OrderDetails.js

<ul><li>Replace hardcoded <code>/admin</code> with <code>Craft.cpTrigger</code> in endpoints<br> <li> Update save-order redirect URL to include <code>Craft.cpTrigger</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/596/files#diff-82a3ebc4b1f3315bef83dc2eecec9321f3de0758f67775c7d630a70a5a96ff33">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clear-orders.twig</strong><dd><code>Dynamic cpTrigger in clear-orders template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/settings/clear-orders.twig

<ul><li>Compute <code>redirectUrl</code> using <code>craft.app.config.general.cpTrigger</code><br> <li> Replace hardcoded data-redirect URL in button<br> <li> Adjust button markup for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/596/files#diff-4760c810172e5d132a8be1226a52564438322e0ef46de7712fa5775ca9dfa45c">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings-check.twig</strong><dd><code>Use dynamic cpTrigger in settings-check template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/settings/settings-check.twig

<ul><li>Define <code>cpTrigger</code> variable from config<br> <li> Update CP links to use <code>{{cpTrigger}}</code> instead of '/admin'<br> <li> Adjust multiple settings URLs for dynamic trigger</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/596/files#diff-7a0f48a7d901a86fa81527c90d388b246969460f67a6a9fd45ffab8ee2ac37e1">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

