### PR TITLE
fixed: neo field UI glitch

### DIFF
--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -1045,16 +1045,16 @@ td.target{
     border-inline-end: none;
 }
 
-#settings, #meta-details {
+#sidebar-settings, #meta-details {
     padding-right: 2.5rem;
 }
 
-#settings .input.ltr:not(.value) {
+#sidebar-settings .input.ltr:not(.value) {
     display: block;
     align-self: center;
 }
 
-#settings .field.button {
+#sidebar-settings .field.button {
     align-items: center;
     justify-content: space-between;
 }

--- a/src/assetbundles/src/js/OrderDetails.js
+++ b/src/assetbundles/src/js/OrderDetails.js
@@ -933,7 +933,7 @@
                     class: "field hidden bg-white",
                     id: "cancel-order-tab"
                 });
-                var settingsDiv = $('#settings div:eq(0)');
+                var settingsDiv = $('#sidebar-settings div:eq(0)');
                 $cancelOrderDiv.insertAfter(settingsDiv);
                 var $cancelOrderHead = $('<div class=heading><label>Order Actions</label></div>');
                 $cancelOrderHead.appendTo($cancelOrderDiv);

--- a/src/assetbundles/src/js/OrderEntries.js
+++ b/src/assetbundles/src/js/OrderEntries.js
@@ -24,7 +24,7 @@
 		init: function() {
 			self = this;
 			this.$publishSelectedBtn = $('#review');
-			this.$translateSelectedBtn = $('#settings').find('button[form=sync-order-google]');
+			this.$translateSelectedBtn = $('#sidebar-settings').find('button[form=sync-order-google]');
 			this.$fileActions = $('#file-actions');
 			this.$selectAllCheckbox = $('.select-all-checkbox :checkbox');
 			this.$checkboxes = $('tbody .translations-checkbox-cell :checkbox').not('[disabled]');

--- a/src/templates/_components/orders/info-tab.twig
+++ b/src/templates/_components/orders/info-tab.twig
@@ -1,6 +1,6 @@
 {% import '_includes/forms' as forms %}
 
-<div id="settings" class="meta">
+<div id="sidebar-settings" class="meta">
 	<div class="field">
 		<div class="heading">
 			<label>Order ID</label>


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Neo field UI breaks due to overlapping css with our plugin so changed the element id in this case and changes made for each use of that id.

### Related Issue(s):

- #598 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

- The sidebar element id so that id does not collides with crafts native css/classes.

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Checkout the UI should not break for any fields created in craft settings.
- Also ensure no plugin pages UI is breaking due to these changes.
- For more details refere linked ticket it contains the affected pages its for neo but lets confirm for each field we use to create entries.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix


___

### **Description**
- Rename settings ID to sidebar-settings to prevent collisions  

- Update JS selectors in OrderDetails.js and OrderEntries.js  

- Modify Twig template to use new sidebar-settings ID  

- Adjust CSS rules in Translations.css to match new ID


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrderDetails.js</strong><dd><code>Update settings selector in OrderDetails.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/OrderDetails.js

<ul><li>Changed selector from <code>$('#settings div:eq(0)')</code>  <br>   to <code>$('#sidebar-settings div:eq(0)')</code><br> <li> Ensured cancel order div inserts after new sidebar container</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/600/files#diff-82a3ebc4b1f3315bef83dc2eecec9321f3de0758f67775c7d630a70a5a96ff33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrderEntries.js</strong><dd><code>Update settings selector in OrderEntries.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/OrderEntries.js

<ul><li>Updated translate button selector from <code>$('#settings')</code>  <br>   to <code>$('#sidebar-settings')</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/600/files#diff-66dca8025c4a82076c000a8d283b21cc35854abb66507d07aeda0a43bbe7fb6d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>info-tab.twig</strong><dd><code>Rename settings ID in Twig template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/templates/_components/orders/info-tab.twig

- Renamed wrapper div ID from `settings` to `sidebar-settings`


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/600/files#diff-604d454f66c987d7d4034171711177ac9af8c0dce0e7829c61ede5fa6ba66294">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Translations.css</strong><dd><code>Update CSS to target sidebar-settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/css/Translations.css

<ul><li>Replaced all <code>#settings</code> selectors with <code>#sidebar-settings</code>  <br> <li> Adjusted nested selector rules under new ID</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/600/files#diff-d3b35b8e1ad4ad28d9bb0b11e7ae78c9be57e4a72bab83cb2efd7c277bfbf78f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

