### PR TITLE
changed: export button defaults to all sites csv download

### DIFF
--- a/src/assetbundles/src/js/StaticTranslations.js
+++ b/src/assetbundles/src/js/StaticTranslations.js
@@ -42,7 +42,7 @@ Craft.Translations.StaticTranslations = {
     },
 
     exportStaticTranslation: function() {
-        params = {
+        const params = {
             sourceKey: Craft.elementIndex.sourceKey,
             search: Craft.elementIndex.searchText
         };
@@ -60,7 +60,7 @@ Craft.Translations.StaticTranslations = {
     },
 
     syncToDB: function (element) { 
-        params = {
+        const params = {
             siteId: Craft.elementIndex.siteId,
             sourceKey: Craft.elementIndex.sourceKey
         };

--- a/src/assetbundles/src/js/StaticTranslations.js
+++ b/src/assetbundles/src/js/StaticTranslations.js
@@ -41,19 +41,8 @@ Craft.Translations.StaticTranslations = {
         });
     },
 
-    exportStaticTranslation: function(bulkExport = false) {
-        let exportSiteIds;
-
-        if (bulkExport) {
-            exportSiteIds = Craft.sites
-                ?.filter(site => site.id !== Craft.primarySiteId)
-                .map(site => site.id) ?? [];
-        } else {
-            exportSiteIds = [Craft.elementIndex.siteId];
-        }
-
+    exportStaticTranslation: function() {
         params = {
-            siteIds: exportSiteIds,
             sourceKey: Craft.elementIndex.sourceKey,
             search: Craft.elementIndex.searchText
         };
@@ -97,7 +86,6 @@ Craft.Translations.StaticTranslations = {
         var self = this;
         var syncToDatabaseButton = $('#sync-static-translation');
         var saveStaticTranslations = $('#save-static-translation');
-        this._createExportButtonGroup();
 
         $('.sortmenubtn').hide();
         $('.statusmenubtn').hide();
@@ -135,57 +123,6 @@ Craft.Translations.StaticTranslations = {
 
         });
     },
-
-    _createExportButtonGroup: function () {
-        const self = this;
-        
-        // Hide the original export button
-        $('#translate-export').hide();
-        
-        // Create button group container
-        const $btngroup = $('<div>', { class: 'btngroup translations-dropdown' });
-        $btngroup.insertAfter('#translate-export');
-
-        // Main Export button
-        this.$btn = $('<a>', {
-            class: 'btn icon translations-submit-order',
-            href: '#',
-            'data-icon': 'download',
-        });
-
-        this.$btn.html("<span class='spinner spinner-absolute translations-loader'></span><div class='label'>Export</div>");
-        this.$btn.appendTo($btngroup);
-
-        // Dropdown menu button
-        this.$menubtn = $('<div>', {
-            class: 'btn menubtn'
-        });
-        this.$menubtn.appendTo($btngroup);
-
-        // Dropdown menu
-        const $menu = $('<div>', { class: 'menu' }).appendTo($btngroup);
-        const $dropdown = $('<ul>').appendTo($menu);
-
-        // Bulk Export menu item
-        const $item = $('<li>').appendTo($dropdown);
-        const $bulkExportLink = $('<a>', {
-            class: 'translations-submit-order update-and-new',
-            href: '#',
-            text: 'Export All Sites'
-        }).appendTo($item);
-
-        this.$btn.on('click', function(e) {
-            e.preventDefault();
-            self.exportStaticTranslation();
-        });
-
-        $bulkExportLink.on('click', function(e) {
-            e.preventDefault();
-            self.exportStaticTranslation(true); // Bulk export
-        });
-
-        new Garnish.MenuBtn(this.$menubtn);
-    }
 };
 
 })(jQuery);

--- a/src/controllers/StaticTranslationsController.php
+++ b/src/controllers/StaticTranslationsController.php
@@ -90,7 +90,11 @@ class StaticTranslationsController extends BaseController
 
         $this->requirePostRequest();
 
-        $siteIds = Craft::$app->request->getRequiredBodyParam('siteIds');
+        $siteIds = array_diff(
+            Craft::$app->getSites()->getAllSiteIds(),
+            [Craft::$app->getSites()->getPrimarySite()->id]
+        );
+
         $source = Craft::$app->request->getRequiredBodyParam('sourceKey');
         $source = str_replace('*', '/', $source);
 

--- a/src/controllers/StaticTranslationsController.php
+++ b/src/controllers/StaticTranslationsController.php
@@ -104,6 +104,11 @@ class StaticTranslationsController extends BaseController
                 'success' => true,
                 'filePath' => $filePath,
             ]);
+        } else if (count($siteIds) === 0) {
+            return $this->asJson([
+                'success' => false,
+                'error' => 'This feature needs multisite setup.'
+            ]);
         }
 
         // If multiple sites are selected, generate CSVs for each site and create a ZIP file


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Make export button in static translations page downloads csv for all sites except default site. 

### Related Issue(s):

- [#610](https://github.com/AcclaroInc/pm-craft-translations/issues/610)

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:

- Tested locally.
- In order to test on dev just make sure the export button in static translations page when clicked downloads a zip file which includes static translations for all sites in csv format.
- And uploading the downloaded zip or single csv should reflect the uploaded content in target site.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Enhancement


___

### **Description**
- Backend now exports all non-primary sites by default

- Frontend removed bulkExport and siteIds parameter logic

- Dropped custom export button group and menu UI

- Simplified exportStaticTranslation signature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FE["Export button clicked"]
  BE["StaticTranslationsController actionExport"]
  BE2["Compute siteIds = allSites − primarySite"]
  ZIP["Generate CSV ZIP"]
  FE -- "POST /export" --> BE
  BE -- "determine siteIds" --> BE2
  BE2 -- "export data" --> ZIP
  ZIP -- "download ZIP" --> FE
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StaticTranslationsController.php</strong><dd><code>Default export all non-primary sites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/controllers/StaticTranslationsController.php

<ul><li>Replaced POST <code>siteIds</code> param with all non-primary site IDs<br> <li> Used <code>array_diff</code> with <code>getAllSiteIds()</code> and primary site ID<br> <li> Removed conditional branch for single-site export</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/601/files#diff-bdd0e6eb552d1b229792f4d44e54237bd4cfe13984563754b773576d38dc5e79">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StaticTranslations.js</strong><dd><code>Simplify static translations export logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/assetbundles/src/js/StaticTranslations.js

<ul><li>Removed <code>bulkExport</code> flag and <code>siteIds</code> parameter<br> <li> Dropped <code>_createExportButtonGroup</code> method and its invocation<br> <li> Simplified <code>exportStaticTranslation</code> to no-arg function<br> <li> Cleaned up export button UI logic</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/601/files#diff-f1474449bc41bbb2d75c1a14bebdb58a5a0d08719e69e9ad81af225d2f4adddc">+1/-64</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

