### PR TITLE
added: permission check in settings

### DIFF
--- a/src/assetbundles/src/js/StaticTranslations.js
+++ b/src/assetbundles/src/js/StaticTranslations.js
@@ -23,7 +23,7 @@ Craft.Translations.StaticTranslations = {
                 Craft.elementIndex.updateElements();
             })
             .catch(({response}) => {
-                Craft.cp.displayError(Craft.t('app', response.data.errors));
+                Craft.cp.displayError(Craft.t('app', response.data.errors.join(', ')));
             })
             .finally(() => {
                 element.removeClass('link-disabled loading');

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -61,6 +61,7 @@ class SettingsController extends BaseController
         $variables['settings']['DOMEnabled'] = extension_loaded('dom');
         $variables['settings']['isMultisite'] = Craft::$app->getIsMultiSite();
         $variables['settings']['sections'] = Craft::$app->getEntries()->getAllSections();
+        $variables['settings']['staticTranslationPermission'] = Translations::$plugin->staticTranslationsRepository->checkPermissions();
 
         foreach (Craft::$app->getFields()->getAllFieldTypes() as $key => $fieldType) {
             if (in_array($fieldType, $supportedFieldTypes)) {

--- a/src/controllers/StaticTranslationsController.php
+++ b/src/controllers/StaticTranslationsController.php
@@ -55,9 +55,16 @@ class StaticTranslationsController extends BaseController
         $lang = $site->language;
         $translations = Craft::$app->request->getRequiredBodyParam('translation');
 
-        Translations::$plugin->staticTranslationsRepository->set($lang, $translations);
-        $job = Translations::$plugin->staticTranslationsRepository->fireStaticTranslationSync();
+        try {
+            Translations::$plugin->staticTranslationsRepository->set($lang, $translations);
+        } catch (\Throwable $e) {
+            return $this->asFailure($this->getErrorMessage($e->getMessage()), [
+                'success' => false,
+                'errors' => [$e->getMessage()]
+            ]);
+        }
 
+        $job = Translations::$plugin->staticTranslationsRepository->fireStaticTranslationSync();
         return $this->asSuccess($this->getSuccessMessage('Static Translations saved.'), [
             'success' => true,
             'jobId' => (int) $job,

--- a/src/migrations/m250502_125548_create_static_translations_table.php
+++ b/src/migrations/m250502_125548_create_static_translations_table.php
@@ -34,9 +34,9 @@ class m250502_125548_create_static_translations_table extends Migration
         $this->createIndex(null, Constants::TABLE_STATIC_TRANSLATIONS, ['siteId']);
         echo "Done creating translations_statictranslations table...\n";
 
-        echo "Seeding static translation to database...\n";
-        (new StaticTranslationsRepository())->syncWithDB();
-        echo "Completed static translation seeding to database...\n";
+        // echo "Seeding static translation to database...\n";
+        // (new StaticTranslationsRepository())->syncWithDB();
+        // echo "Completed static translation seeding to database...\n";
 
         return true;
     }

--- a/src/templates/settings/settings-check.twig
+++ b/src/templates/settings/settings-check.twig
@@ -64,6 +64,23 @@
         </tbody>
     </table>
 
+    {# FileSystem Permissions for Static Translations #}
+    <h2>{{ "FileSystem Permissions for Static Translations"|t('app') }}</h2>
+    <table class="data fullwidth" dir="ltr">
+        <tbody>
+            <tr>
+                <td class="thin centeralign">
+                    {% if settings.staticTranslationPermission.success == true %}
+                        <span class="success" title="{{ 'Success'|t('app') }}" data-icon="check"></span>
+                    {% else %}
+                        <span class="error" title="{{ 'Error'|t('app') }}" data-icon="alert"></span>
+                    {% endif %}
+                </td>
+                <td>{{ settings.staticTranslationPermission.message }}</td>
+            </tr>
+        </tbody>
+    </table>
+
     <h2>{{ "Section Propagation Methods"|t('app') }}</h2>
     <table class="data fullwidth" dir="ltr">
         <tbody>


### PR DESCRIPTION
## Pull Request

### Description:
This addresses the issue users facing when running migration and failing due to permission issues with translations directory.
So to prevent this we have removed the ssync job run from inside the migration.

### Related Issue(s):

- #404 

### Changes Made:

**Added:**

- File system permission check in setttings page.

**Changed:**

-

**Deprecated:**

-

**Removed:**

- Static translation sync job trigger from migration.

**Fixed:**

- Fixed issue where actual error was not shown to the user despite internal server error was showing inc ase of any error.

**Security:**

-

### Testing:

- Tested locally with multiple directory permission scenarios.
- Deployed to dev for QA.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**

Settings page when craft has read/write permission to translations directory.
<img width="1310" height="505" alt="image" src="https://github.com/user-attachments/assets/79184270-ad46-489c-8f9b-aa5d80a4bc0c" />

Settings page in case lack of permission to translations directory.
<img width="1208" height="499" alt="image" src="https://github.com/user-attachments/assets/47ae578b-28fc-454c-9dc7-7c4a940114f1" />

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


