### PR TITLE
fixed: entry content reversion

### DIFF
--- a/src/Translations.php
+++ b/src/Translations.php
@@ -69,9 +69,9 @@ class Translations extends Plugin
     public static $view;
 
     /**
-     * @var bool
+     * @var bool|null
      */
-    public static bool $suppressDraftDeleteLog = false;
+    public static ?bool $suppressDraftDeleteLog = null;
 
     // Public Methods
     // =========================================================================

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -68,6 +68,11 @@ class Translations extends Plugin
      */
     public static $view;
 
+    /**
+     * @var bool
+     */
+    public static bool $suppressDraftDeleteLog = false;
+
     // Public Methods
     // =========================================================================
 
@@ -727,7 +732,7 @@ class Translations extends Plugin
 
     private function _onDeleteElement(Event $event)
     {
-		if (!empty($event->element->draftId)) {
+		if (!self::$suppressDraftDeleteLog && !empty($event->element->draftId)) {
 			$response = self::$plugin->draftRepository->isTranslationDraft($event->element->draftId);
 			if ($response) {
 

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -253,7 +253,7 @@ class DraftRepository
                 $order,
                 $wordCounts,
                 $draftMap['content'],
-                false,
+                false
             );
         }
 
@@ -284,19 +284,22 @@ class DraftRepository
      */
     private function _deleteOtherDrafts(array $fileDraftMap, int $currentFileId): array
     {
-        Translations::$suppressDraftDeleteLog = true;
         $deletedFileIds = [];
-        foreach ($fileDraftMap as $fileId => $draftMap) {
-            if ((int)$fileId !== (int)$currentFileId) {
-                $existingFile = Translations::$plugin->fileRepository->getFileById($fileId);
-                $this->deleteDraft($draftMap['draft_id'], $existingFile->targetSite);
-                $existingFile->status = Constants::FILE_STATUS_REVIEW_READY;
-                $existingFile->draftId = 0;
-                Translations::$plugin->fileRepository->saveFile($existingFile);
-                $deletedFileIds[] = (int)$fileId;
+        Translations::$suppressDraftDeleteLog = true;
+        try {
+            foreach ($fileDraftMap as $fileId => $draftMap) {
+                if ((int)$fileId !== (int)$currentFileId) {
+                    $existingFile = Translations::$plugin->fileRepository->getFileById($fileId);
+                    $this->deleteDraft($draftMap['draft_id'], $existingFile->targetSite);
+                    $existingFile->status = Constants::FILE_STATUS_REVIEW_READY;
+                    $existingFile->draftId = 0;
+                    Translations::$plugin->fileRepository->saveFile($existingFile);
+                    $deletedFileIds[] = (int)$fileId;
+                }
             }
+        } finally {
+            Translations::$suppressDraftDeleteLog = false;
         }
-        Translations::$suppressDraftDeleteLog = false;
         return $deletedFileIds;
     }
 

--- a/src/services/repository/DraftRepository.php
+++ b/src/services/repository/DraftRepository.php
@@ -184,6 +184,8 @@ class DraftRepository
     public function createOrderDrafts($orderId, $wordCounts, $publish, $fileIds, $queue=null)
     {
         $isNewDraft = false;
+        $draftsDeleted = false;
+        $recreatedDraftFileIds = [];
         $order = Translations::$plugin->orderRepository->getOrderById($orderId);
 
         $totalElements = count($order->getFiles());
@@ -191,9 +193,21 @@ class DraftRepository
 
         $createDrafts = new CreateDrafts();
         
+        $fileDraftMap = $this->_getFileDraftMap($order); 
         foreach ($order->getFiles() as $file) {
             if (! in_array($file->id, $fileIds)) {
                 continue;
+            }
+            $draftContent = $fileDraftMap[$file->id]['content'] ?? null; // stores the content of the draft temporarily
+            unset($fileDraftMap[$file->id]);
+
+            // Delete other drafts only if there is more than one fileId and drafts already exists
+            if ($publish && !$draftsDeleted && (count($fileIds) > 1 || count($fileDraftMap) > 1)) {
+                $deleted = $this->_deleteOtherDrafts($fileDraftMap, $file->id);
+                $draftsDeleted = true;
+                if (!empty($deleted)) {
+                    $recreatedDraftFileIds = array_merge($recreatedDraftFileIds, $deleted);
+                }
             }
 
             try {
@@ -201,43 +215,22 @@ class DraftRepository
                 only that will be rolledback and others can be processed */
                 $transaction = Craft::$app->db->getTransaction() === null ? Craft::$app->db->beginTransaction() : null;
     
-                $element = Translations::$plugin->elementRepository->getElementById($file->elementId, $order->sourceSite);
-                $isFileReady = $file->isReviewReady();
-    
                 if ($queue) {
                     $createDrafts->updateProgress($queue, $currentElement++/$totalElements);
                 }
-    
-                // Create draft only if not already exist
-                if ($file->hasDraft()) {
-                    $file->status = Constants::FILE_STATUS_COMPLETE;
-                    Translations::$plugin->fileRepository->saveFile($file);
-                } else {
-                    $isNewDraft = $this->createDrafts($element, $order, $file->targetSite, $wordCounts, $file);
-                }
 
-                /**
-                 * Only allow draft merge once, as merging multiple times
-                 * will cause issues with the non-localised blocks duplication.
-                 */
-                if ($isFileReady) {
-                    // Translation Service Always Local
-                    $translationService = $order->getTranslationService();
+                $isRecreate = in_array($file->id, $recreatedDraftFileIds, true);
 
-                    $translationService->updateIOFile($order, $file);
+                $isNewDraft = $this->processFileDraft(
+                    $file,
+                    $order,
+                    $wordCounts,
+                    $draftContent,
+                    $publish,
+                    $queue,
+                    $isRecreate
+                );
 
-                    Translations::$plugin->fileRepository->saveFile($file);
-                }
-
-                /**
-                 * Updated applyDrafts logic to apply drafts individually v.s all at once
-                 * - https://github.com/AcclaroInc/pm-craft-translations/issues/388
-                 * - https://github.com/craftcms/cms/issues/9966
-                 * - https://github.com/AcclaroInc/craft-translations/pull/236/commits/813ef41548532ec41a5f53da6eb4194259f64071
-                 **/
-                if ($publish) {
-                    $this->applyDrafts($order->id, [$element->id], [$file->id], $queue);
-                }
                 if ($transaction !== null) {
                     $transaction->commit();
                 }
@@ -248,6 +241,20 @@ class DraftRepository
                 $this->setError($e->getMessage());
                 continue;
             }
+        }
+
+        /**
+         *  Recreate drafts for deleted but unprocessed files
+        */
+        foreach ($fileDraftMap as $remainingFileId => $draftMap) {
+            $file = Translations::$plugin->fileRepository->getFileById($remainingFileId);
+            $isNewDraft = $this->processFileDraft(
+                $file,
+                $order,
+                $wordCounts,
+                $draftMap['content'],
+                false,
+            );
         }
 
         if ($isNewDraft)
@@ -261,6 +268,108 @@ class DraftRepository
 
         Translations::$plugin->orderRepository->saveOrder($order);
         Translations::$plugin->cacheHelper->invalidateCache(Constants::CACHE_RESET_ORDER_CHANGES);
+    }
+
+    /**
+     * Deletes old drafts to resolve an issue with non-localized matrix blocks containing localized fields.
+     * 
+     * When merging drafts while one or more drafts already exist, content may be lost 
+     * both in the parent site and in all target sites except the last one.  
+     * 
+     * To prevent this, we delete existing drafts first. This mimics the behavior of 
+     * creating drafts from scratch, ensuring the merge process runs without content loss.
+     *
+     * @param array $fileDraftMap
+     * @param int $currentFileId
+     */
+    private function _deleteOtherDrafts(array $fileDraftMap, int $currentFileId): array
+    {
+        Translations::$suppressDraftDeleteLog = true;
+        $deletedFileIds = [];
+        foreach ($fileDraftMap as $fileId => $draftMap) {
+            if ((int)$fileId !== (int)$currentFileId) {
+                $existingFile = Translations::$plugin->fileRepository->getFileById($fileId);
+                $this->deleteDraft($draftMap['draft_id'], $existingFile->targetSite);
+                $existingFile->status = Constants::FILE_STATUS_REVIEW_READY;
+                $existingFile->draftId = 0;
+                Translations::$plugin->fileRepository->saveFile($existingFile);
+                $deletedFileIds[] = (int)$fileId;
+            }
+        }
+        Translations::$suppressDraftDeleteLog = false;
+        return $deletedFileIds;
+    }
+
+    /**
+     * Gets an array of file id vs draft id mapping for the given order and files
+     * @param OrderModel $order
+     * @param array $fileIds
+     * @return array
+     */
+    private function _getFileDraftMap($order)
+    {
+        $fileDraftMap = [];
+        foreach ($order->getFiles() as $file) {
+            $draft = $file->hasDraft();
+            if ($draft) {
+                $fileDraftMap[$file->id] = [
+                    'draft_id' => $draft->draftId,
+                    'content' => Translations::$plugin->elementToFileConverter->convert(
+                        $draft,
+                        Constants::FILE_FORMAT_XML,
+                        [
+                            'sourceSite'    => $order->sourceSite,
+                            'targetSite'    => $file->targetSite,
+                            'wordCount'     => Translations::$plugin->elementTranslator->getWordCount($draft),
+                            'orderId'       => $order->id
+                        ]
+                    )
+                ];
+            }
+        }
+
+        return $fileDraftMap;
+    }
+
+    /**
+    * Process a single file's draft creation/update logic.
+    */
+    private function processFileDraft($file, $order, $wordCounts, $draftContent, $publish, $queue=null, $isRecreate = true)
+    {
+        $isNewDraft = false;
+
+        $element = Translations::$plugin->elementRepository->getElementById($file->elementId, $order->sourceSite);
+        $currentFile = Translations::$plugin->fileRepository->getFileById($file->id);
+        $isFileReady = $currentFile->isReviewReady();
+
+
+        if ($file->hasDraft()) {
+            $file->status = Constants::FILE_STATUS_COMPLETE;
+            Translations::$plugin->fileRepository->saveFile($file);
+        } else {
+            $draftCreated = $this->createDrafts($element, $order, $file->targetSite, $wordCounts, $file);
+            if ($draftCreated && !$isRecreate) {
+                $isNewDraft = true;
+            }
+        }
+
+        if ($isFileReady) {
+            $translationService = $order->getTranslationService();
+            $translationService->updateIOFile($order, $file, $draftContent);
+            Translations::$plugin->fileRepository->saveFile($file);
+        }
+
+        /**
+         * Updated applyDrafts logic to apply drafts individually v.s all at once
+         * - https://github.com/AcclaroInc/pm-craft-translations/issues/388
+         * - https://github.com/craftcms/cms/issues/9966
+         * - https://github.com/AcclaroInc/craft-translations/pull/236/commits/813ef41548532ec41a5f53da6eb4194259f64071
+        **/
+        if ($publish) {
+            $this->applyDrafts($order->id, [$element->id], [$file->id], $queue);
+        }
+
+        return $isNewDraft;
     }
 
     public function createDrafts($element, $order, $site, $wordCounts, $file=null)

--- a/src/services/translator/Export_ImportTranslationService.php
+++ b/src/services/translator/Export_ImportTranslationService.php
@@ -95,9 +95,9 @@ class Export_ImportTranslationService implements TranslationServiceInterface
         return [];
     }
 
-    public function updateIOFile(Order $order, FileModel $file)
+    public function updateIOFile(Order $order, FileModel $file, ?string $existingDraftContent = null)
     {
-        $target = $file->target;
+        $target = $existingDraftContent ?? $file->target;
         $file->dateDelivered = new \DateTime();
 
         $element = Translations::$plugin->elementRepository->getElementById($file->elementId, $file->sourceSite);


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Entry content is getting reverted to previous version when multiple draft are applied togather.

### Related Issue(s):

- [#609](https://github.com/AcclaroInc/pm-craft-translations/issues/609)

### Changes Made:

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

- multiple draft content reversion issue.

**Security:**

-

### Testing:

Tested loacally.
Deployed on dev server for QA.

- Create an order with multiple target sites more than 3. (Use any entry with nested strucutures and also having localised fields at root level of entry)
- Translated the downloaded fiels and upload back.
- Create draft for more than 3 files togather.
- Apply all drafts togather and make sure every field in entry has the translated content.
- To be on safer side test all possible ways a user can create and apply drafts.

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent draft content loss on publish

- Delete/recreate conflicting drafts safely

- Preserve and reuse existing draft content

- Suppress noisy draft-delete activity logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Order with multiple files"] -- "Map existing drafts" --> B["_getFileDraftMap"]
  B -- "if publish & multiple" --> C["Delete other drafts"]
  C -- "suppress logs" --> C1["suppressDraftDeleteLog=true"]
  C -- "collect deleted ids" --> D["recreatedDraftFileIds"]
  A -- "per file" --> E["processFileDraft"]
  E -- "reuse existing draft content" --> F["updateIOFile(order, file, content)"]
  E -- "apply individually if publish" --> G["applyDrafts(...)"]
  B -- "remaining unmapped" --> H["Recreate drafts for leftovers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Translations.php</strong><dd><code>Add suppression for draft delete logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Translations.php

<ul><li>Add <code>Translations::$suppressDraftDeleteLog</code> static flag.<br> <li> Guard draft-delete logging in <code>_onDeleteElement</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/605/files#diff-5dbabf28f99c5bb5952de16ae00245df569895ed48a3a196b329c34bb48ce8f9">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Export_ImportTranslationService.php</strong><dd><code>Support injecting existing draft content in updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/translator/Export_ImportTranslationService.php

<ul><li>Allow <code>updateIOFile</code> to accept existing draft content.<br> <li> Prefer provided draft content over file target.</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/605/files#diff-c596e4de6d8bbb414a72da7568a85d01c4c5cf5282a4f70185f6b4ad75ff8622">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DraftRepository.php</strong><dd><code>Safe multi-draft handling and content preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/repository/DraftRepository.php

<ul><li>Delete existing drafts when publishing multiple to avoid content loss.<br> <li> Capture and reuse existing draft content per file.<br> <li> Extract <code>processFileDraft</code> helper to centralize logic.<br> <li> Recreate drafts for unprocessed/deleted files.</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/605/files#diff-4885c24694510a7cf322200be77380b1218416eff7332687469fc6a4fd8dd0d8">+140/-31</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

