### PR TITLE
fixed: missing new translation button from multiple pages

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,7 +1,7 @@
 {
     "pluginName": "Translations for Craft",
     "pluginDescription": "Drive global growth with simplified translation workflows.",
-    "pluginVersion": "v4.1.6",
+    "pluginVersion": "v4.1.7",
     "pluginAuthorName": "Acclaro",
     "pluginVendorName": "Acclaro",
     "pluginAuthorUrl": "http://www.acclaro.com/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.7 - 2026-03-05
+
+### Fixed
+- Missing new translation button from different pages.
+- Miss aligned slector issue on global edit pages.
+
 ## 4.1.6 - 2026-02-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.1.7 - 2026-03-05
+## 4.1.7 - 2026-03-06
 
 ### Fixed
 - Missing new translation button from different pages.
-- Miss aligned slector issue on global edit pages.
+- Missaligned selector issue on global edit pages.
 
 ## 4.1.6 - 2026-02-25
 

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -432,8 +432,7 @@ class Translations extends Plugin
     private function _includeResources($path)
     {
         $this->_includeUniversalResources();
-
-        if (preg_match('#^entries(/|$)#', $path)) {
+        if (preg_match('#^content/entries(/|$)#', $path)) {
             $this->_includeEntryResources();
         }
         // Only matches for commerce products

--- a/src/assetbundles/src/css/Translations.css
+++ b/src/assetbundles/src/css/Translations.css
@@ -1063,3 +1063,8 @@ td.target{
     display: flex;
     align-items: center;
 }
+
+.global-edit.select {
+    max-width: fit-content;
+    margin-left: 10em;
+}

--- a/src/assetbundles/src/js/AddEntriesToTranslationOrder.js
+++ b/src/assetbundles/src/js/AddEntriesToTranslationOrder.js
@@ -53,6 +53,7 @@ Craft.Translations.AddEntriesToTranslationOrder = {
 
         $(this.$btn[0]).toggleClass('link-disabled', this.entries.length === 0);
         $(this.$menubtn[0]).toggleClass('link-disabled', this.entries.length === 0);
+        $(this.$btn[0]).find(".btn-text").toggleClass('display-none', this.entries.length === 0);
 
         this.updateCreateNewLink();
     },
@@ -138,12 +139,11 @@ Craft.Translations.AddEntriesToTranslationOrder = {
             var $headinggroup = $('<div>', {'class': 'heading'}).html('<label id="translations-label" for="translations">Translations</label>');
             var $inputgroup = $('<div>', {'class': 'input ltr'});
 
-
             $headinggroup.appendTo($btncontainer);
             $inputgroup.appendTo($btncontainer);
             $btngroup.appendTo($inputgroup);
         } else if(! (this.isRevertRevisionScreen() || this.isEditDraftScreen() || this.isCreateEntryScreen())) {
-            $btngroup.insertBefore('header#header > div:last');
+            $btngroup.insertAfter('header#header > div:last');
         }
 
         this.$btn = $('<a>', {
@@ -152,7 +152,7 @@ Craft.Translations.AddEntriesToTranslationOrder = {
             'data-icon': "language",
         });
 
-        this.$btn.html("<span>" + Craft.t('app', 'New translation') + "</span>");
+        this.$btn.html("<span class='btn-text'>" + Craft.t('app', 'New translation') + "</span>");
 
         this.$menubtn = $('<div>', {
             'class': 'btn menubtn'
@@ -161,6 +161,7 @@ Craft.Translations.AddEntriesToTranslationOrder = {
         if (!this.isEditEntryScreen()) {
             this.$btn.addClass('link-disabled');
             this.$menubtn.addClass('link-disabled');
+            this.$btn.find(".btn-text").addClass('display-none');
         }
 
         this.$btn.appendTo($btngroup);
@@ -201,7 +202,7 @@ Craft.Translations.AddEntriesToTranslationOrder = {
 
             var $link = $('<a>', {
                 'href': '#',
-                'text': 'Add to '+order.title
+                'text': 'Add to order "'+order.title+'"'
             });
 
             $link.appendTo($item);

--- a/src/assetbundles/src/js/AddTranslationsToCommerce.js
+++ b/src/assetbundles/src/js/AddTranslationsToCommerce.js
@@ -40,7 +40,7 @@
                 this.$btngroup.appendTo($inputgroup);
                 $inputgroup.appendTo($btncontainer);
             } else if (this.isIndexScreen()) {
-                this.$btngroup.insertBefore('header#header > div:last');
+                this.$btngroup.insertAfter('header#header > div:last');
             }
 
             this.$btn = $('<a>', {
@@ -98,7 +98,7 @@
 
                 var $link = $('<a>', {
                     'href': '#',
-                    'text': 'Add to '+order.title
+                    'text': 'Add to order "'+order.title+'"'
                 });
 
                 $link.appendTo($item);

--- a/src/assetbundles/src/js/AssetsTranslations.js
+++ b/src/assetbundles/src/js/AssetsTranslations.js
@@ -95,7 +95,7 @@ Craft.Translations.AssetsTranslations = {
             $inputgroup.appendTo($btncontainer);
             $btngroup.appendTo($inputgroup);
         } else {
-            $btngroup.insertBefore('header#header > div:last');
+            $btngroup.insertAfter('header#header > div:last');
         }
 
 
@@ -155,7 +155,7 @@ Craft.Translations.AssetsTranslations = {
 
             var $link = $('<a>', {
                 'href': '#',
-                'text': 'Add to '+order.title
+                'text': 'Add to order "'+order.title+'"'
             });
 
             $link.appendTo($item);

--- a/src/assetbundles/src/js/CategoryTranslations.js
+++ b/src/assetbundles/src/js/CategoryTranslations.js
@@ -101,9 +101,8 @@ Craft.Translations.CategoryTranslations = {
             $inputgroup.appendTo($btncontainer);
             $btngroup.appendTo($inputgroup);
         } else if (!this.isCreatingFresh()) {
-            $btngroup.insertBefore('#header #action-buttons');
+            $btngroup.insertAfter('header#header > div:last');
         }
-
 
         this.$btn = $('<a>', {
             'class': 'btn icon',
@@ -161,7 +160,7 @@ Craft.Translations.CategoryTranslations = {
 
             var $link = $('<a>', {
                 'href': '#',
-                'text': 'Add to '+order.title
+                'text': 'Add to order "'+order.title+'"'
             });
 
             $link.appendTo($item);

--- a/src/assetbundles/src/js/GlobalSetEdit.js
+++ b/src/assetbundles/src/js/GlobalSetEdit.js
@@ -12,7 +12,7 @@ Craft.Translations.GlobalSetEdit = {
     },
 
     initDraftsDropdown: function(drafts) {
-        var $container = $('<div>', {'class': 'select'}).css('margin-left', '0.75em');
+        var $container = $('<div>', {'class': 'select global-edit'});
 
         var $select = $('<select>');
 
@@ -36,7 +36,7 @@ Craft.Translations.GlobalSetEdit = {
             $option.appendTo($select);
         });
 
-        $container.appendTo('#page-title');
+        $container.appendTo('#revision-indicators');
     },
 
     initSaveDraftButton: function() {
@@ -135,7 +135,7 @@ Craft.Translations.GlobalSetEdit = {
 
             var $link = $('<a>', {
                 'href': '#',
-                'text': 'Add to '+order.title
+                'text': 'Add to order "'+order.title+'"'
             });
 
             $link.appendTo($item);


### PR DESCRIPTION
## Pull Request

### Description:
Fixes missing new translation buttons on different pages like entries, categories, global sets, assets, craft commerce products etc for both index and detail pages.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- #627

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

- Missing crete translation buttons.
- CSS mislaigning revision versioning dropdown.

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


