### PR TITLE
added: support for content block and link field

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -195,6 +195,7 @@ class Constants
     const NESTED_FIELD_TYPES = [
         'craft\fields\Matrix',
         'craft\fields\Assets',
+		'craft\fields\ContentBlock',
 		'verbb\vizy\fields\VizyField',
         'verbb\navigation\fields\NavigationField',
         'verbb\supertable\fields\SuperTableField',

--- a/src/services/fieldtranslator/ContentBlockFieldTranslator.php
+++ b/src/services/fieldtranslator/ContentBlockFieldTranslator.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Translations for Craft plugin for Craft CMS 3.x
+ *
+ * Translations for Craft eliminates error prone and costly copy/paste workflows for launching human translated Craft CMS web content.
+ *
+ * @link      http://www.acclaro.com/
+ * @copyright Copyright (c) 2018 Acclaro
+ */
+
+namespace acclaro\translations\services\fieldtranslator;
+
+use Craft;
+use craft\base\Element;
+use craft\base\Field;
+use acclaro\translations\Constants;
+use acclaro\translations\Translations;
+use acclaro\translations\services\ElementTranslator;
+
+class ContentBlockFieldTranslator extends GenericFieldTranslator
+{
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite = null)
+    {
+        $contentBlock = $this->getContentBlock($element, $field);
+
+        if (!$contentBlock) {
+            return [];
+        }
+
+        $source = [];
+
+        foreach ($this->getChildFields($contentBlock) as $childField) {
+            $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($childField);
+
+            if (!$translator || !$this->shouldTranslateChildField($contentBlock, $childField)) {
+                continue;
+            }
+
+            $fieldSource = $translator->toTranslationSource($elementTranslator, $contentBlock, $childField, $sourceSite);
+
+            if (!is_array($fieldSource)) {
+                $fieldSource = [$childField->handle => $fieldSource];
+            }
+
+            foreach ($fieldSource as $key => $value) {
+                $source[sprintf('%s.%s', $field->handle, $key)] = $value;
+            }
+        }
+
+        return $source;
+    }
+
+    public function toPostArray(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $contentBlock = $this->getContentBlock($element, $field);
+
+        if (!$contentBlock) {
+            return [
+                $field->handle => [
+                    'fields' => [],
+                ],
+            ];
+        }
+
+        $fields = [];
+
+        foreach ($this->getChildFields($contentBlock) as $childField) {
+            $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($childField);
+
+            if (!$translator || !$this->shouldTranslateChildField($contentBlock, $childField)) {
+                continue;
+            }
+
+            $fieldPost = $translator->toPostArray($elementTranslator, $contentBlock, $childField);
+
+            if (!is_array($fieldPost)) {
+                $fieldPost = [$childField->handle => $fieldPost];
+            }
+
+            $fields = array_merge($fields, $fieldPost);
+        }
+
+        return [
+            $field->handle => [
+                'fields' => $fields,
+            ],
+        ];
+    }
+
+    public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite, $targetSite, $fieldData)
+    {
+        $contentBlock = $this->getContentBlock($element, $field);
+
+        if (!$contentBlock) {
+            return [
+                $field->handle => [
+                    'fields' => [],
+                ],
+            ];
+        }
+
+        $fields = [];
+
+        foreach ($this->getChildFields($contentBlock) as $childField) {
+            $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($childField);
+
+            if (!$translator || !$this->shouldTranslateChildField($contentBlock, $childField)) {
+                continue;
+            }
+
+            if (isset($fieldData[$childField->handle])) {
+                $fieldPost = $translator->toPostArrayFromTranslationTarget(
+                    $elementTranslator,
+                    $contentBlock,
+                    $childField,
+                    $sourceSite,
+                    $targetSite,
+                    $fieldData[$childField->handle]
+                );
+            } else {
+                $fieldPost = $translator->toPostArray($elementTranslator, $contentBlock, $childField);
+            }
+
+            if (!is_array($fieldPost)) {
+                $fieldPost = [$childField->handle => $fieldPost];
+            }
+
+            $fields = array_merge($fields, $fieldPost);
+        }
+
+        return [
+            $field->handle => [
+                'fields' => $fields,
+            ],
+        ];
+    }
+
+    public function getWordCount(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $contentBlock = $this->getContentBlock($element, $field);
+
+        if (!$contentBlock) {
+            return 0;
+        }
+
+        $wordCount = 0;
+
+        foreach ($this->getChildFields($contentBlock) as $childField) {
+            $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($childField);
+
+            if ($translator && $this->shouldTranslateChildField($contentBlock, $childField)) {
+                $wordCount += $translator->getWordCount($elementTranslator, $contentBlock, $childField);
+            }
+        }
+
+        return $wordCount;
+    }
+
+    private function getContentBlock(Element $element, Field $field)
+    {
+        try {
+            return $element->getFieldValue($field->handle);
+        } catch (\Exception $e) {
+            Translations::$plugin->logHelper->log(
+                '[' . __METHOD__ . "] {$field->handle} not found.",
+                Constants::LOG_LEVEL_ERROR
+            );
+            return null;
+        }
+    }
+
+    private function getChildFields(Element $contentBlock): array
+    {
+        $fields = [];
+
+        foreach ($contentBlock->getFieldLayout()->getCustomFields() as $layoutField) {
+            $field = Craft::$app->fields->getFieldById($layoutField->id);
+
+            if (!$field) {
+                continue;
+            }
+
+            $field->handle = $layoutField->handle;
+            $fields[] = $field;
+        }
+
+        return $fields;
+    }
+
+    private function shouldTranslateChildField(Element $contentBlock, Field $childField): bool
+    {
+        return $childField->getIsTranslatable($contentBlock)
+            || in_array(get_class($childField), Constants::NESTED_FIELD_TYPES, true);
+    }
+}

--- a/src/services/fieldtranslator/ContentBlockFieldTranslator.php
+++ b/src/services/fieldtranslator/ContentBlockFieldTranslator.php
@@ -181,8 +181,9 @@ class ContentBlockFieldTranslator extends GenericFieldTranslator
                 continue;
             }
 
-            $field->handle = $layoutField->handle;
-            $fields[] = $field;
+            $resolvedField = clone $field;
+            $resolvedField->handle = $layoutField->handle;
+            $fields[] = $resolvedField;
         }
 
         return $fields;

--- a/src/services/fieldtranslator/Factory.php
+++ b/src/services/fieldtranslator/Factory.php
@@ -10,14 +10,15 @@
 
 namespace acclaro\translations\services\fieldtranslator;
 
-use Craft;
 use craft\base\Field;
 use craft\fields\Tags;
 use craft\fields\Table;
 use craft\fields\Assets;
+use craft\fields\Link;
 use craft\fields\Matrix;
 use craft\fields\Number;
 use craft\fields\Entries;
+use craft\fields\ContentBlock;
 use craft\fields\Dropdown;
 use craft\fields\PlainText;
 use craft\fields\Categories;
@@ -53,8 +54,10 @@ class Factory
         Assets::class           => AssetsFieldTranslator::class,
         Categories::class       => CategoryFieldTranslator::class,
         Checkboxes::class       => MultiSelectFieldTranslator::class,
+        ContentBlock::class     => ContentBlockFieldTranslator::class,
         Dropdown::class         => SingleOptionFieldTranslator::class,
         Entries::class          => EntriesFieldTranslator::class,
+        Link::class             => LinkFieldTranslator::class,
         Matrix::class           => MatrixFieldTranslator::class,
         MultiSelect::class      => MultiSelectFieldTranslator::class,
         TypedLinkField::class   => TypedLinkFieldTranslator::class,

--- a/src/services/fieldtranslator/LinkFieldTranslator.php
+++ b/src/services/fieldtranslator/LinkFieldTranslator.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Translations for Craft plugin for Craft CMS 3.x
+ *
+ * Translations for Craft eliminates error prone and costly copy/paste workflows for launching human translated Craft CMS web content.
+ *
+ * @link      http://www.acclaro.com/
+ * @copyright Copyright (c) 2018 Acclaro
+ */
+
+namespace acclaro\translations\services\fieldtranslator;
+
+use craft\base\Element;
+use craft\base\Field;
+use craft\fields\data\LinkData;
+use acclaro\translations\Translations;
+use acclaro\translations\services\ElementTranslator;
+
+class LinkFieldTranslator extends GenericFieldTranslator
+{
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $fieldData = $this->getFieldValue($elementTranslator, $element, $field);
+
+        if (!$fieldData instanceof LinkData) {
+            return [];
+        }
+
+        $serialized = $fieldData->serialize();
+
+        if (!isset($serialized['label']) || $serialized['label'] === '') {
+            return [];
+        }
+
+        return [
+            sprintf('%s.%s.label', $field->handle, $field->id) => $serialized['label'],
+        ];
+    }
+
+    public function toPostArray(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $fieldData = $this->getFieldValue($elementTranslator, $element, $field);
+
+        return [
+            $field->handle => $fieldData instanceof LinkData ? $fieldData->serialize() : null,
+        ];
+    }
+
+    public function toPostArrayFromTranslationTarget(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite, $targetSite, $fieldData)
+    {
+        $post = $this->toPostArray($elementTranslator, $element, $field);
+
+        if (!is_array($post[$field->handle] ?? null)) {
+            return $post;
+        }
+
+        foreach ($fieldData as $key => $row) {
+            if ((string)$key !== (string)$field->id || !is_array($row)) {
+                continue;
+            }
+
+            if (isset($row['label'])) {
+                $post[$field->handle]['label'] = $row['label'];
+            }
+        }
+
+        return $post;
+    }
+
+    public function getWordCount(ElementTranslator $elementTranslator, Element $element, Field $field)
+    {
+        $fieldData = $this->getFieldValue($elementTranslator, $element, $field);
+
+        if (!$fieldData instanceof LinkData) {
+            return 0;
+        }
+
+        return Translations::$plugin->wordCounter->getWordCount(strip_tags($fieldData->getLabel(true) ?? ''));
+    }
+}

--- a/src/services/fieldtranslator/LinkFieldTranslator.php
+++ b/src/services/fieldtranslator/LinkFieldTranslator.php
@@ -19,7 +19,7 @@ use acclaro\translations\services\ElementTranslator;
 
 class LinkFieldTranslator extends GenericFieldTranslator
 {
-    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field)
+    public function toTranslationSource(ElementTranslator $elementTranslator, Element $element, Field $field, $sourceSite = null)
     {
         $fieldData = $this->getFieldValue($elementTranslator, $element, $field);
 


### PR DESCRIPTION
### **User description**
## Pull Request

### Description:
Support for craft native content block and link field.

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- #628 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- Support for Link field's localisation.
- Support for content block localisation.

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ContentBlock` field translation handling

- Translate nested child field content

- Add `Link` field label localization

- Register new translators and nested types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  factory["Field translator factory"]
  cb["ContentBlockFieldTranslator"]
  link["LinkFieldTranslator"]
  nested["Nested child fields"]
  labels["Link field labels"]
  constants["Nested field type list"]
  factory -- "maps `ContentBlock`" --> cb
  factory -- "maps `Link`" --> link
  cb -- "extracts and rebuilds" --> nested
  link -- "translates" --> labels
  constants -- "includes `ContentBlock`" --> cb
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Constants.php</strong><dd><code>Recognize `ContentBlock` as nested translatable field</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Constants.php

<ul><li>Add <code>craft\fields\ContentBlock</code> to <code>NESTED_FIELD_TYPES</code><br> <li> Enable nested translation traversal for content blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/631/files#diff-6aed81ccd7b0bf73a127d3e240dd2b18df7c0d9c8ab4eaf7cb906570e0ceaefd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContentBlockFieldTranslator.php</strong><dd><code>Handle translation lifecycle for content blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/fieldtranslator/ContentBlockFieldTranslator.php

<ul><li>Add a dedicated translator for <code>ContentBlock</code> fields<br> <li> Gather child field sources with dotted keys<br> <li> Rebuild nested post payloads for translations<br> <li> Count words and log missing block values</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/631/files#diff-f7cf7db976b7bd20ea80d713fdb8a19dc7c7de6314585a7025e17ddd9970ccad">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Factory.php</strong><dd><code>Register translators for `ContentBlock` and `Link`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/fieldtranslator/Factory.php

<ul><li>Import Craft <code>ContentBlock</code> and <code>Link</code> field classes<br> <li> Register <code>ContentBlockFieldTranslator</code> for <code>ContentBlock</code><br> <li> Register <code>LinkFieldTranslator</code> for <code>Link</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/631/files#diff-1b1507c9664bda2d97280b78d0938609e1f1537c891460ba988d35eacc73be58">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LinkFieldTranslator.php</strong><dd><code>Translate `Link` field labels and payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/fieldtranslator/LinkFieldTranslator.php

<ul><li>Add translator support for <code>LinkData</code> field values<br> <li> Export only non-empty <code>label</code> text for translation<br> <li> Merge translated labels back into serialized link payloads<br> <li> Count words from stripped link labels</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/631/files#diff-749710a5ba373e1790c9aedb2aa645c3c5aacc3289ed7b18af6e21ddf3dbc088">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

