### PR TITLE
Neo block sub-field silently dropped on import (image-block captions …

### DIFF
--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -42,7 +42,9 @@ class ElementTranslator
             $field = clone Craft::$app->fields->getFieldById($layoutField->id);
             $field->handle = $layoutField->handle;
             $fieldSource = $this->fieldToTranslationSource($element, $field, $sourceSite);
-
+            if (!empty($fieldSource)) {
+               $source["__fieldmap__.{$field->uid}"] = $field->handle;
+            }
             $source = array_merge($source, $fieldSource);
         }
 
@@ -165,7 +167,10 @@ class ElementTranslator
             $field = clone Craft::$app->fields->getFieldById($layoutField->id);
             $fieldHandle = $layoutField->handle;
             $field->handle = $layoutField->handle;
-
+            if (isset($targetData['__fieldmap__']) && isset($targetData['__fieldmap__'][$field->uid])) {
+               $fieldHandle = $targetData['__fieldmap__'][$field->uid];
+               $field->handle = $fieldHandle;
+            }
             $fieldType = $field;
 
             $translator = Translations::$plugin->fieldTranslatorFactory->makeTranslator($fieldType);
@@ -190,11 +195,58 @@ class ElementTranslator
             }
 
             $fieldPost = [];
-            if (isset($targetData[$fieldHandle])) {
-                    $fieldPost = $translator->toPostArrayFromTranslationTarget($this, $element, $field, $sourceSite, $targetSite, $targetData[$fieldHandle]);
-            } else {
-                $fieldPost = $translator->toPostArray($this, $element, $field, $sourceSite);
+            $originalField = Craft::$app->fields->getFieldById($layoutField->id);
+
+            $translationValue = null;
+            $possibleHandles = [
+               $layoutField->handle,
+               $originalField->handle,
+            ];
+
+            $exportedHandle = null;
+
+            if (isset($targetData['__fieldmap__'])) {
+               foreach ($targetData['__fieldmap__'] as $uid => $handle) {
+                    if ($uid === $field->uid) {
+                       $exportedHandle = $handle;
+                       break;
+                    }
+                }
             }
+            if ($exportedHandle) {
+               $possibleHandles[] = $exportedHandle;
+            }
+
+            $possibleHandles = array_filter(array_unique($possibleHandles));
+            foreach ($possibleHandles as $handle) {
+                if (isset($targetData[$handle])) {
+                    $translationValue = $targetData[$handle];
+                    break;
+                }
+            }
+
+            if ($translationValue !== null) {
+               $fieldPost = $translator->toPostArrayFromTranslationTarget(
+                    $this,
+                    $element,
+                    $field,
+                    $sourceSite,
+                    $targetSite,
+                    $translationValue
+                );
+            } else {
+                $fieldPost = $translator->toPostArray(
+                    $this,
+                    $element,
+                    $field,
+                    $sourceSite
+                );
+            }
+            // if (isset($targetData[$fieldHandle])) {
+            //         $fieldPost = $translator->toPostArrayFromTranslationTarget($this, $element, $field, $sourceSite, $targetSite, $targetData[$fieldHandle]);
+            // } else {
+            //     $fieldPost = $translator->toPostArray($this, $element, $field, $sourceSite);
+            // }
 
             if (!is_array($fieldPost)) {
                 $fieldPost = array($fieldHandle => $fieldPost);

--- a/src/services/ElementTranslator.php
+++ b/src/services/ElementTranslator.php
@@ -39,7 +39,7 @@ class ElementTranslator
         }
 
         foreach ($element->getFieldLayout()->getCustomFields() as $layoutField) {
-            $field = Craft::$app->fields->getFieldById($layoutField->id);
+            $field = clone Craft::$app->fields->getFieldById($layoutField->id);
             $field->handle = $layoutField->handle;
             $fieldSource = $this->fieldToTranslationSource($element, $field, $sourceSite);
 
@@ -162,8 +162,9 @@ class ElementTranslator
         $post = array();
 
         foreach($element->getFieldLayout()->getCustomFields() as $key => $layoutField) {
-            $field = Craft::$app->fields->getFieldById($layoutField->id);
-            $fieldHandle = $field->handle = $layoutField->handle;
+            $field = clone Craft::$app->fields->getFieldById($layoutField->id);
+            $fieldHandle = $layoutField->handle;
+            $field->handle = $layoutField->handle;
 
             $fieldType = $field;
 


### PR DESCRIPTION
### **User description**
…lost, Seagull/BarTender) #632

## Pull Request

### Description:
[Provide a brief description of the purpose and goal of this pull request.]

### Related Issue(s):
[Cite any related issues or feature requests, using the GitHub issue link.]

- 

### Changes Made:
[List the changes made in this pull request to address the issue or implement the feature.]

**Added:**

- 

**Changed:**

-

**Deprecated:**

-

**Removed:**

-

**Fixed:**

-

**Security:**

-

### Testing:
[Describe the testing performed to ensure the changes are functioning as expected.]

- 

### Quality Assurance (QA):

- [ ] The code has been reviewed and approved by the QA team.
- [ ] The changes have been tested on different environments (e.g., staging, production).
- [ ] Integration tests have been performed to verify the interactions between components.
- [ ] Performance tests have been conducted to ensure the changes do not impact system performance.
- [ ] Any necessary database migrations or data transformations have been executed successfully.
- [ ] Accessibility requirements have been considered and tested (e.g., screen reader compatibility, keyboard navigation).

### Resources:

**Screenshots (if applicable):**
[Include any relevant screenshots to visually demonstrate the changes.]

### Wrapping up

**Checklist:**

- [ ] The code builds without any errors or warnings.
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] Unit tests have been added or updated to cover the changes made.
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing tests pass successfully.
- [ ] The PR has been reviewed by at least one other team member.

**Additional Notes:**
[Include any additional notes, considerations, or context that may be relevant.]


___

### **PR Type**
Bug fix


___

### **Description**
- Clone fields before applying layout handles

- Preserve Neo sub-fields during translation imports

- Prevent shared field configuration mutation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  layout["Layout-specific field handle"]
  clone["Cloned field instance"]
  translation["Translation export and import"]
  layout -- "applied to" --> clone
  clone -- "preserves sub-fields in" --> translation
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ElementTranslator.php</strong><dd><code>Clone Fields Before Applying Translation Handles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/ElementTranslator.php

<ul><li>Clones fields before assigning layout-specific handles<br> <li> Avoids mutating shared Craft field instances<br> <li> Preserves Neo sub-fields across translation processing</ul>


</details>


  </td>
  <td><a href="https://github.com/AcclaroInc/craft-translations/pull/653/files#diff-ad1a5b56e1b533079d25cdd42b37b73b50441ba5a8c243cd9f99f0bff1789cca">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

